### PR TITLE
Add minimal admin tool for customer management

### DIFF
--- a/admin/add_customer.php
+++ b/admin/add_customer.php
@@ -1,0 +1,42 @@
+<?php
+session_start();
+if(empty($_SESSION['admin'])){header('Location: login.php');exit;}
+function getPDO(){
+    $host=getenv('DB_HOST')?:'localhost';
+    $db=getenv('DB_NAME')?:'app';
+    $user=getenv('DB_USER')?:'root';
+    $pass=getenv('DB_PASS')?:'';
+    try{return new PDO("mysql:host=$host;dbname=$db;charset=utf8mb4",$user,$pass,[PDO::ATTR_ERRMODE=>PDO::ERRMODE_EXCEPTION]);}
+    catch(PDOException $e){die('DB connection failed: '.htmlspecialchars($e->getMessage()));}
+}
+$pdo=getPDO();
+$error='';
+if($_SERVER['REQUEST_METHOD']==='POST'){
+    $email=trim($_POST['email']??'');
+    $first=trim($_POST['first_name']??'');
+    $last=trim($_POST['last_name']??'');
+    $phone=trim($_POST['phone']??'');
+    if($email && filter_var($email,FILTER_VALIDATE_EMAIL)){
+        $stmt=$pdo->prepare('INSERT INTO customers (email,first_name,last_name,phone) VALUES (?,?,?,?)');
+        try{$stmt->execute([$email,$first,$last,$phone]);header('Location: dashboard.php');exit;}
+        catch(PDOException $e){$error='Error: '.htmlspecialchars($e->getMessage());}
+    }else $error='Valid email required';
+}
+?>
+<!DOCTYPE html>
+<html>
+<head><meta charset="UTF-8"><title>Add Customer</title>
+<style>body{font-family:Arial;margin:2em}form{max-width:400px}input{width:100%;padding:.5em;margin:.3em 0}button{background:#52b3a4;color:#fff;border:none;padding:.5em 1em}</style>
+</head>
+<body>
+<h2 style="color:#4a90b8">Add Customer</h2>
+<?php if($error) echo "<p style='color:red'>$error</p>"; ?>
+<form method="post">
+<input name="email" placeholder="Email" required>
+<input name="first_name" placeholder="First Name">
+<input name="last_name" placeholder="Last Name">
+<input name="phone" placeholder="Phone">
+<button type="submit">Save</button>
+</form>
+<p><a href="dashboard.php" style="color:#52b3a4">Back</a></p>
+</body></html>

--- a/admin/dashboard.php
+++ b/admin/dashboard.php
@@ -1,0 +1,38 @@
+<?php
+session_start();
+if(empty($_SESSION['admin'])){header('Location: login.php');exit;}
+function getPDO(){
+    $host=getenv('DB_HOST')?:'localhost';
+    $db=getenv('DB_NAME')?:'app';
+    $user=getenv('DB_USER')?:'root';
+    $pass=getenv('DB_PASS')?:'';
+    try{return new PDO("mysql:host=$host;dbname=$db;charset=utf8mb4",$user,$pass,[PDO::ATTR_ERRMODE=>PDO::ERRMODE_EXCEPTION]);}
+    catch(PDOException $e){die('DB connection failed: '.htmlspecialchars($e->getMessage()));}
+}
+$pdo=getPDO();
+if(isset($_GET['logout'])){session_destroy();header('Location: login.php');exit;}
+$customers=$pdo->query('SELECT * FROM customers ORDER BY created_at DESC')->fetchAll(PDO::FETCH_ASSOC);
+?>
+<!DOCTYPE html>
+<html>
+<head><meta charset="UTF-8"><title>Dashboard</title>
+<style>body{font-family:Arial;margin:2em}nav a{margin-right:1em;color:#52b3a4}table{width:100%;border-collapse:collapse}th,td{border:1px solid #ccc;padding:.4em}th{background:#4a90b8;color:#fff}</style>
+</head>
+<body>
+<header><h2 style="color:#4a90b8">Dashboard</h2></header>
+<nav>
+<a href="add_customer.php">Add Customer</a>
+<a href="?logout=1">Logout</a>
+</nav>
+<table>
+<tr><th>Email</th><th>Name</th><th>Phone</th><th>Status</th></tr>
+<?php foreach($customers as $c): ?>
+<tr>
+<td><?=htmlspecialchars($c['email'])?></td>
+<td><?=htmlspecialchars($c['first_name'].' '.$c['last_name'])?></td>
+<td><?=htmlspecialchars($c['phone'])?></td>
+<td><?=htmlspecialchars($c['status'])?></td>
+</tr>
+<?php endforeach; ?>
+</table>
+</body></html>

--- a/admin/login.php
+++ b/admin/login.php
@@ -1,0 +1,38 @@
+<?php
+session_start();
+function getPDO(){
+    $host=getenv('DB_HOST')?:'localhost';
+    $db=getenv('DB_NAME')?:'app';
+    $user=getenv('DB_USER')?:'root';
+    $pass=getenv('DB_PASS')?:'';
+    try{return new PDO("mysql:host=$host;dbname=$db;charset=utf8mb4",$user,$pass,[PDO::ATTR_ERRMODE=>PDO::ERRMODE_EXCEPTION]);}
+    catch(PDOException $e){die('DB connection failed: '.htmlspecialchars($e->getMessage()));}
+}
+$pdo=getPDO();
+$error='';
+if($_SERVER['REQUEST_METHOD']==='POST'){
+    $stmt=$pdo->prepare('SELECT * FROM admin_users WHERE username=?');
+    $stmt->execute([$_POST['username']??'']);
+    $user=$stmt->fetch(PDO::FETCH_ASSOC);
+    if($user && password_verify($_POST['password']??'', $user['password_hash'])){
+        $_SESSION['admin']=$user['username'];
+        header('Location: dashboard.php');
+        exit;
+    }
+    $error='Invalid credentials';
+}
+?>
+<!DOCTYPE html>
+<html>
+<head><meta charset="UTF-8"><title>Login</title>
+<style>body{font-family:Arial;margin:2em}form{max-width:300px;margin:auto}input,button{width:100%;padding:.5em;margin:.3em 0}button{background:#4a90b8;color:#fff;border:none}</style>
+</head>
+<body>
+<h2 style="color:#4a90b8;text-align:center">Admin Login</h2>
+<?php if($error) echo "<p style='color:red'>$error</p>";?>
+<form method="post">
+<input name="username" placeholder="Username" required>
+<input type="password" name="password" placeholder="Password" required>
+<button type="submit">Login</button>
+</form>
+</body></html>

--- a/admin/setup.php
+++ b/admin/setup.php
@@ -1,0 +1,46 @@
+<?php
+function getPDO(){
+    $host=getenv('DB_HOST')?:'localhost';
+    $db=getenv('DB_NAME')?:'app';
+    $user=getenv('DB_USER')?:'root';
+    $pass=getenv('DB_PASS')?:'';
+    try{
+        return new PDO("mysql:host=$host;dbname=$db;charset=utf8mb4",$user,$pass,[PDO::ATTR_ERRMODE=>PDO::ERRMODE_EXCEPTION]);
+    }catch(PDOException $e){
+        die('DB connection failed: '.htmlspecialchars($e->getMessage()));
+    }
+}
+$pdo=getPDO();
+$pdo->exec("CREATE TABLE IF NOT EXISTS admin_users (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    username VARCHAR(50) UNIQUE NOT NULL,
+    password_hash VARCHAR(255) NOT NULL,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+CREATE TABLE IF NOT EXISTS customers (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    email VARCHAR(100) UNIQUE NOT NULL,
+    first_name VARCHAR(50),
+    last_name VARCHAR(50),
+    phone VARCHAR(30),
+    status VARCHAR(20) DEFAULT 'active',
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);");
+$check=$pdo->prepare('SELECT COUNT(*) FROM admin_users WHERE username=?');
+$check->execute(['admin']);
+if(!$check->fetchColumn()){
+    $hash=password_hash('password123',PASSWORD_DEFAULT);
+    $ins=$pdo->prepare('INSERT INTO admin_users (username,password_hash) VALUES (?,?)');
+    $ins->execute(['admin',$hash]);
+}
+?>
+<!DOCTYPE html>
+<html>
+<head><meta charset="UTF-8"><title>Setup</title>
+<style>body{font-family:Arial;margin:2em;color:#333}a{color:#4a90b8}</style>
+</head>
+<body>
+<h2>Setup Complete</h2>
+<p>Tables created and default admin user added.</p>
+<p><a href="login.php">Go to Login</a></p>
+</body></html>


### PR DESCRIPTION
## Summary
- add setup script to create tables and default admin
- implement session-based login
- provide dashboard with customer list and simple add-customer form

## Testing
- `php -l admin/setup.php admin/login.php admin/dashboard.php admin/add_customer.php`


------
https://chatgpt.com/codex/tasks/task_e_68bbddb483948323a7cb76015b31e2b5