### PR TITLE
Add customer PIN authentication system

### DIFF
--- a/admin/dashboard.php
+++ b/admin/dashboard.php
@@ -42,16 +42,38 @@ $customers = $pdo->query('SELECT * FROM customers ORDER BY created_at DESC')->fe
     <a href="add_customer.php">Add Customer</a>
     <a href="?logout=1">Logout</a>
 </nav>
+<?php if(!empty($_GET['success'])): ?>
+    <p style="color:green;"><?=htmlspecialchars($_GET['success'])?></p>
+<?php elseif(!empty($_GET['error'])): ?>
+    <p style="color:red;"><?=htmlspecialchars($_GET['error'])?></p>
+<?php endif; ?>
 <p>Total customers: <?=$total?></p>
 <table>
-    <tr><th>Email</th><th>Name</th><th>Phone</th><th>Status</th><th>Created</th></tr>
+    <tr><th>Email</th><th>Name</th><th>Phone</th><th>Status</th><th>Created</th><th>PIN Status</th><th>Action</th></tr>
     <?php foreach($customers as $c): ?>
+    <?php
+        $pinStatus = 'No PIN';
+        if(!empty($c['pin']) && !empty($c['pin_expires'])){
+            if(strtotime($c['pin_expires']) < time()){
+                $pinStatus = 'PIN expired';
+            }else{
+                $pinStatus = 'PIN sent (expires: '.htmlspecialchars($c['pin_expires']).')';
+            }
+        }
+    ?>
     <tr>
         <td><?=htmlspecialchars($c['email'])?></td>
         <td><?=htmlspecialchars(trim($c['first_name'].' '.$c['last_name']))?></td>
         <td><?=htmlspecialchars($c['phone'])?></td>
         <td><?=htmlspecialchars($c['status'])?></td>
         <td><?=htmlspecialchars($c['created_at'])?></td>
+        <td><?=$pinStatus?></td>
+        <td>
+            <form method="post" action="send_pin.php" style="margin:0;">
+                <input type="hidden" name="customer_id" value="<?=$c['id']?>">
+                <button type="submit">Send PIN</button>
+            </form>
+        </td>
     </tr>
     <?php endforeach; ?>
 </table>

--- a/admin/send_pin.php
+++ b/admin/send_pin.php
@@ -1,0 +1,44 @@
+<?php
+session_start();
+if(empty($_SESSION['admin'])){header('Location: login.php');exit;}
+function getPDO(){
+    $config = require __DIR__ . '/config.php';
+    try{
+        return new PDO(
+            "mysql:host={$config['DB_HOST']};dbname={$config['DB_NAME']};charset=utf8mb4",
+            $config['DB_USER'],
+            $config['DB_PASS'],
+            [PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION]
+        );
+    }catch(PDOException $e){
+        die('DB connection failed: '.htmlspecialchars($e->getMessage()));
+    }
+}
+if($_SERVER['REQUEST_METHOD'] === 'POST' && !empty($_POST['customer_id'])){
+    $cid = (int)$_POST['customer_id'];
+    $pdo = getPDO();
+    $stmt = $pdo->prepare('SELECT email, first_name FROM customers WHERE id = ?');
+    $stmt->execute([$cid]);
+    $cust = $stmt->fetch(PDO::FETCH_ASSOC);
+    if(!$cust){
+        header('Location: dashboard.php?error='.urlencode('Customer not found'));
+        exit;
+    }
+    $pin = sprintf('%06d', random_int(100000, 999999));
+    $pin_hash = password_hash($pin, PASSWORD_DEFAULT);
+    $expires = date('Y-m-d H:i:s', strtotime('+15 minutes'));
+    $upd = $pdo->prepare('UPDATE customers SET pin = ?, pin_expires = ? WHERE id = ?');
+    $upd->execute([$pin_hash, $expires, $cid]);
+    $subject = 'Ihr Zugangspin';
+    $message = "Hallo {$cust['first_name']},\n\nIhr PIN lautet: $pin\nEr ist gültig bis $expires.\n\nViele Grüße\nAnna Braun Lerncoaching";
+    $headers = 'From: Anna Braun Lerncoaching <no-reply@einfachlernen.app>';
+    if(mail($cust['email'], $subject, $message, $headers)){
+        header('Location: dashboard.php?success='.urlencode('PIN sent'));
+    }else{
+        header('Location: dashboard.php?error='.urlencode('Email sending failed'));
+    }
+    exit;
+}
+header('Location: dashboard.php?error='.urlencode('Invalid request'));
+exit;
+?>

--- a/admin/setup.php
+++ b/admin/setup.php
@@ -35,6 +35,18 @@ try {
         status VARCHAR(20) DEFAULT 'active',
         created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
     )");
+    try { $pdo->exec("ALTER TABLE customers ADD COLUMN pin VARCHAR(255) NULL"); } catch (Exception $e) {}
+    try { $pdo->exec("ALTER TABLE customers ADD COLUMN pin_expires DATETIME NULL"); } catch (Exception $e) {}
+    try { $pdo->exec("ALTER TABLE customers ADD COLUMN last_login DATETIME NULL"); } catch (Exception $e) {}
+
+    $pdo->exec("CREATE TABLE IF NOT EXISTS customer_sessions (
+        id INT AUTO_INCREMENT PRIMARY KEY,
+        customer_id INT NOT NULL,
+        session_token VARCHAR(64) UNIQUE NOT NULL,
+        expires_at DATETIME NOT NULL,
+        created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+        FOREIGN KEY (customer_id) REFERENCES customers(id) ON DELETE CASCADE
+    )");
 
     $check = $pdo->prepare('SELECT COUNT(*) FROM admin_users WHERE username = ?');
     $check->execute(['admin']);

--- a/customer/auth.php
+++ b/customer/auth.php
@@ -1,0 +1,58 @@
+<?php
+if(session_status() === PHP_SESSION_NONE){
+    session_start();
+}
+function getPDO(){
+    $config = require __DIR__.'/../admin/config.php';
+    try{
+        return new PDO(
+            "mysql:host={$config['DB_HOST']};dbname={$config['DB_NAME']};charset=utf8mb4",
+            $config['DB_USER'],
+            $config['DB_PASS'],
+            [PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION]
+        );
+    }catch(PDOException $e){
+        die('DB connection failed: '.htmlspecialchars($e->getMessage()));
+    }
+}
+function cleanup_sessions($pdo){
+    $pdo->exec('DELETE FROM customer_sessions WHERE expires_at < NOW()');
+}
+function create_customer_session($customer_id){
+    $pdo = getPDO();
+    cleanup_sessions($pdo);
+    $token = bin2hex(random_bytes(32));
+    $expires = date('Y-m-d H:i:s', strtotime('+7 days'));
+    $stmt = $pdo->prepare('INSERT INTO customer_sessions (customer_id, session_token, expires_at) VALUES (?, ?, ?)');
+    $stmt->execute([$customer_id, $token, $expires]);
+    setcookie('customer_session', $token, time()+7*24*3600, '/', '', false, true);
+}
+function get_current_customer(){
+    if(empty($_COOKIE['customer_session'])){
+        return null;
+    }
+    $pdo = getPDO();
+    cleanup_sessions($pdo);
+    $token = $_COOKIE['customer_session'];
+    $stmt = $pdo->prepare('SELECT c.* FROM customer_sessions s JOIN customers c ON c.id = s.customer_id WHERE s.session_token = ? AND s.expires_at > NOW()');
+    $stmt->execute([$token]);
+    return $stmt->fetch(PDO::FETCH_ASSOC);
+}
+function require_customer_login(){
+    $cust = get_current_customer();
+    if(!$cust){
+        header('Location: /login.php');
+        exit;
+    }
+    return $cust;
+}
+function destroy_customer_session(){
+    if(!empty($_COOKIE['customer_session'])){
+        $token = $_COOKIE['customer_session'];
+        $pdo = getPDO();
+        $stmt = $pdo->prepare('DELETE FROM customer_sessions WHERE session_token = ?');
+        $stmt->execute([$token]);
+        setcookie('customer_session','',time()-3600,'/', '', false, true);
+    }
+}
+?>

--- a/customer/index.php
+++ b/customer/index.php
@@ -1,0 +1,33 @@
+<?php
+require __DIR__.'/auth.php';
+if(isset($_GET['logout'])){
+    destroy_customer_session();
+    header('Location: /login.php');
+    exit;
+}
+$customer = require_customer_login();
+?>
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Customer Area</title>
+    <style>
+        body{font-family:Arial;margin:2em;color:#333}
+        a{color:#52b3a4}
+        header{color:#4a90b8}
+    </style>
+</head>
+<body>
+<header><h2>Welcome, <?=htmlspecialchars($customer['first_name'])?></h2></header>
+<nav><a href="?logout=1">Logout</a></nav>
+<p>Email: <?=htmlspecialchars($customer['email'])?></p>
+<p>Name: <?=htmlspecialchars(trim($customer['first_name'].' '.$customer['last_name']))?></p>
+<p>Phone: <?=htmlspecialchars($customer['phone'])?></p>
+<p>Status: <?=htmlspecialchars($customer['status'])?></p>
+<?php if(!empty($customer['last_login'])): ?>
+<p>Last login: <?=htmlspecialchars($customer['last_login'])?></p>
+<?php endif; ?>
+</body>
+</html>

--- a/login.php
+++ b/login.php
@@ -1,0 +1,53 @@
+<?php
+require __DIR__.'/customer/auth.php';
+$pdo = getPDO();
+$error = '';
+if($_SERVER['REQUEST_METHOD'] === 'POST'){
+    $email = trim($_POST['email'] ?? '');
+    $pin = trim($_POST['pin'] ?? '');
+    if($email === '' || $pin === ''){
+        $error = 'Please enter email and PIN.';
+    }else{
+        $stmt = $pdo->prepare('SELECT * FROM customers WHERE email = ?');
+        $stmt->execute([$email]);
+        $cust = $stmt->fetch(PDO::FETCH_ASSOC);
+        if(!$cust){
+            $error = 'Invalid email or PIN.';
+        }elseif(empty($cust['pin']) || empty($cust['pin_expires']) || strtotime($cust['pin_expires']) < time()){
+            $error = 'PIN expired or invalid.';
+        }elseif(!password_verify($pin, $cust['pin'])){
+            $error = 'Invalid email or PIN.';
+        }else{
+            create_customer_session($cust['id']);
+            $upd = $pdo->prepare('UPDATE customers SET pin = NULL, pin_expires = NULL, last_login = NOW() WHERE id = ?');
+            $upd->execute([$cust['id']]);
+            header('Location: customer/index.php');
+            exit;
+        }
+    }
+}
+?>
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Customer Login</title>
+    <style>
+        body{font-family:Arial;margin:2em;color:#333}
+        label{display:block;margin-top:1em}
+        input{padding:.4em;width:100%;max-width:300px}
+        button{margin-top:1em;padding:.5em 1em;background:#4a90b8;color:#fff;border:none;cursor:pointer}
+        a{color:#52b3a4}
+    </style>
+</head>
+<body>
+<h2 style="color:#4a90b8">Customer Login</h2>
+<?php if($error): ?><p style="color:red;"><?=$error?></p><?php endif; ?>
+<form method="post">
+    <label>Email<br><input type="email" name="email" required></label>
+    <label>PIN<br><input type="password" name="pin" required></label>
+    <button type="submit">Login</button>
+</form>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Allow admins to send temporary PINs to customers from the dashboard
- Add customer login and session system using emailed PIN codes
- Create customer dashboard and auth helpers
- Extend setup with PIN columns and session table

## Testing
- `php -l admin/dashboard.php`
- `php -l admin/send_pin.php`
- `php -l login.php`
- `php -l customer/auth.php`
- `php -l customer/index.php`
- `php -l admin/setup.php`


------
https://chatgpt.com/codex/tasks/task_e_68bbe14e26b08323b7327649c08c5c7f