### PR TITLE
Improve PIN email debugging and dashboard status display

### DIFF
--- a/admin/send_pin.php
+++ b/admin/send_pin.php
@@ -21,24 +21,45 @@ if($_SERVER['REQUEST_METHOD'] === 'POST' && !empty($_POST['customer_id'])){
     $stmt->execute([$cid]);
     $cust = $stmt->fetch(PDO::FETCH_ASSOC);
     if(!$cust){
-        header('Location: dashboard.php?error='.urlencode('Customer not found'));
+        echo "<h2 style='color:red'>❌ Customer not found</h2>";
+        echo "<p><a href='dashboard.php?error=".urlencode('Customer not found')."'>← Back to Dashboard</a></p>";
         exit;
     }
+
     $pin = sprintf('%06d', random_int(100000, 999999));
     $pin_hash = password_hash($pin, PASSWORD_DEFAULT);
     $expires = date('Y-m-d H:i:s', strtotime('+15 minutes'));
     $upd = $pdo->prepare('UPDATE customers SET pin = ?, pin_expires = ? WHERE id = ?');
     $upd->execute([$pin_hash, $expires, $cid]);
+
     $subject = 'Ihr Zugangspin';
     $message = "Hallo {$cust['first_name']},\n\nIhr PIN lautet: $pin\nEr ist gültig bis $expires.\n\nViele Grüße\nAnna Braun Lerncoaching";
-    $headers = 'From: Anna Braun Lerncoaching <no-reply@einfachlernen.app>';
-    if(mail($cust['email'], $subject, $message, $headers)){
-        header('Location: dashboard.php?success='.urlencode('PIN sent'));
-    }else{
-        header('Location: dashboard.php?error='.urlencode('Email sending failed'));
+    $headers = [
+        'From: Anna Braun Lerncoaching <noreply@einfachstarten.jetzt>',
+        'Reply-To: info@einfachlernen.jetzt',
+        'X-Mailer: PHP/' . phpversion(),
+        'Content-Type: text/plain; charset=UTF-8',
+        'MIME-Version: 1.0'
+    ];
+    $headers_string = implode("\r\n", $headers);
+
+    if(mail($cust['email'], $subject, $message, $headers_string)){
+        echo "<h2 style='color:green'>✅ PIN Sent Successfully</h2>";
+        echo "<p><strong>Recipient:</strong> " . htmlspecialchars($cust['email']) . "</p>";
+        echo "<p><strong>PIN:</strong> $pin (for testing only)</p>";
+        echo "<p><strong>Expires:</strong> $expires</p>";
+        echo "<p><a href='dashboard.php?success=" . urlencode('PIN sent to ' . $cust['email']) . "'>← Back to Dashboard</a></p>";
+    } else {
+        echo "<h2 style='color:red'>❌ Email Sending Failed</h2>";
+        echo "<p><strong>Recipient:</strong> " . htmlspecialchars($cust['email']) . "</p>";
+        $error = error_get_last();
+        echo "<p><strong>Error:</strong> " . ($error['message'] ?? 'Unknown mail error') . "</p>";
+        echo "<p><strong>Server:</strong> " . $_SERVER['SERVER_NAME'] . "</p>";
+        echo "<p><a href='dashboard.php?error=" . urlencode('Email sending failed') . "'>← Back to Dashboard</a></p>";
     }
     exit;
 }
-header('Location: dashboard.php?error='.urlencode('Invalid request'));
+echo "<h2 style='color:red'>❌ Invalid request</h2>";
+echo "<p><a href='dashboard.php?error=" . urlencode('Invalid request') . "'>← Back to Dashboard</a></p>";
 exit;
 ?>

--- a/admin/test_mail.php
+++ b/admin/test_mail.php
@@ -1,0 +1,38 @@
+<?php
+session_start();
+if(empty($_SESSION['admin'])){header('Location: login.php');exit;}
+
+echo "<h2>World4you mail() Test</h2>";
+
+if($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $test_email = $_POST['test_email'] ?? 'marcus@einfachstarten.jetzt';
+    
+    $subject = 'Test Email from Anna Braun CMS';
+    $message = "This is a test email sent at " . date('Y-m-d H:i:s') . "\n\n";
+    $message .= "If you receive this, mail() function is working correctly.\n\n";
+    $message .= "Server: " . $_SERVER['SERVER_NAME'] . "\n";
+    $message .= "PHP Version: " . phpversion();
+    
+    $headers = 'From: Anna Braun Test <noreply@einfachstarten.jetzt>' . "\r\n" .
+               'Reply-To: info@einfachlernen.jetzt' . "\r\n" .
+               'X-Mailer: PHP/' . phpversion();
+    
+    $result = mail($test_email, $subject, $message, $headers);
+    
+    if($result) {
+        echo "<p style='color:green'>✅ mail() returned TRUE - check email delivery</p>";
+    } else {
+        echo "<p style='color:red'>❌ mail() returned FALSE</p>";
+        $error = error_get_last();
+        echo "<p>Last error: " . ($error['message'] ?? 'No error details') . "</p>";
+    }
+}
+?>
+
+<form method="post">
+    <label>Test Email Address:</label><br>
+    <input type="email" name="test_email" value="marcus@einfachstarten.jetzt" required><br><br>
+    <button type="submit">Send Test Email</button>
+</form>
+
+<p><a href="dashboard.php">← Back to Dashboard</a></p>


### PR DESCRIPTION
## Summary
- show detailed success/error output when sending PINs with improved mail headers
- add PIN status tracking and clearer alerts on the dashboard
- provide admin test page for verifying PHP mail setup

## Testing
- `php -l admin/send_pin.php`
- `php -l admin/dashboard.php`
- `php -l admin/test_mail.php`


------
https://chatgpt.com/codex/tasks/task_e_68bbe45fed5c8323983f4e196c2c6626