### PR TITLE
Enhance PIN and test email formatting with professional headers

### DIFF
--- a/admin/send_pin.php
+++ b/admin/send_pin.php
@@ -1,4 +1,6 @@
 <?php
+mb_internal_encoding('UTF-8');
+mb_http_output('UTF-8');
 session_start();
 if(empty($_SESSION['admin'])){header('Location: login.php');exit;}
 function getPDO(){
@@ -32,29 +34,68 @@ if($_SERVER['REQUEST_METHOD'] === 'POST' && !empty($_POST['customer_id'])){
     $upd = $pdo->prepare('UPDATE customers SET pin = ?, pin_expires = ? WHERE id = ?');
     $upd->execute([$pin_hash, $expires, $cid]);
 
-    $subject = 'Ihr Zugangspin';
-    $message = "Hallo {$cust['first_name']},\n\nIhr PIN lautet: $pin\nEr ist gültig bis $expires.\n\nViele Grüße\nAnna Braun Lerncoaching";
-    $headers = [
-        'From: Anna Braun Lerncoaching <noreply@einfachstarten.jetzt>',
-        'Reply-To: info@einfachlernen.jetzt',
-        'X-Mailer: PHP/' . phpversion(),
-        'Content-Type: text/plain; charset=UTF-8',
-        'MIME-Version: 1.0'
-    ];
-    $headers_string = implode("\r\n", $headers);
+    // TODO: Implement rate limiting - max 3 PIN requests per hour per email
+    // TODO: Log PIN generation attempts for security monitoring
 
-    if(mail($cust['email'], $subject, $message, $headers_string)){
-        echo "<h2 style='color:green'>✅ PIN Sent Successfully</h2>";
-        echo "<p><strong>Recipient:</strong> " . htmlspecialchars($cust['email']) . "</p>";
-        echo "<p><strong>PIN:</strong> $pin (for testing only)</p>";
-        echo "<p><strong>Expires:</strong> $expires</p>";
-        echo "<p><a href='dashboard.php?success=" . urlencode('PIN sent to ' . $cust['email']) . "'>← Back to Dashboard</a></p>";
+    $subject = 'Ihr Login-Code für Anna Braun Lerncoaching';
+
+    $message = "Liebe/r {$cust['first_name']},\n\n";
+    $message .= "Sie haben einen Login-Code für Ihr Kundenkonto angefordert.\n\n";
+    $message .= "🔐 Ihr Login-Code: $pin\n";
+    $message .= "⏰ Gültig bis: " . date('d.m.Y um H:i', strtotime($expires)) . " Uhr\n\n";
+    $message .= "► Zum Login: https://einfachstarten.jetzt/einfachlernen/login.php\n\n";
+    $message .= "Aus Sicherheitsgründen ist dieser Code nur 15 Minuten gültig.\n";
+    $message .= "Falls Sie diesen Code nicht angefordert haben, können Sie diese E-Mail ignorieren.\n\n";
+    $message .= "Bei Fragen stehen wir Ihnen gerne zur Verfügung.\n\n";
+    $message .= "Mit freundlichen Grüßen\n";
+    $message .= "Anna Braun\n";
+    $message .= "Ganzheitliches Lerncoaching\n\n";
+    $message .= "---\n";
+    $message .= "Anna Braun Lerncoaching\n";
+    $message .= "E-Mail: info@einfachlernen.jetzt\n";
+    $message .= "Web: www.einfachlernen.jetzt\n";
+    $message .= "Diese E-Mail wurde automatisch generiert.";
+
+    $headers = 'From: Anna Braun Lerncoaching <info@einfachlernen.jetzt>' . "\r\n" .
+               'Reply-To: info@einfachlernen.jetzt' . "\r\n" .
+               'Return-Path: info@einfachlernen.jetzt' . "\r\n" .
+               'Message-ID: <' . uniqid() . '.' . time() . '@einfachlernen.jetzt>' . "\r\n" .
+               'Date: ' . date('r') . "\r\n" .
+               'X-Mailer: Anna Braun CMS v1.0' . "\r\n" .
+               'X-Priority: 3 (Normal)' . "\r\n" .
+               'Importance: Normal' . "\r\n" .
+               'Content-Type: text/plain; charset=UTF-8' . "\r\n" .
+               'Content-Transfer-Encoding: 8bit' . "\r\n" .
+               'MIME-Version: 1.0' . "\r\n" .
+               'Organization: Anna Braun Lerncoaching';
+
+    $mail_result = mail($cust['email'], $subject, $message, $headers);
+
+    if($mail_result){
+        echo "<h2 style='color:green'>✅ E-Mail erfolgreich versendet</h2>";
+        echo "<p><strong>Empfänger:</strong> " . htmlspecialchars($cust['email']) . "</p>";
+        echo "<p><strong>Login-Code:</strong> <code style='background:#f0f0f0;padding:5px;'>$pin</code></p>";
+        echo "<p><strong>Gültig bis:</strong> " . date('d.m.Y um H:i', strtotime($expires)) . " Uhr</p>";
+        echo "<div style='background:#d4edda;padding:15px;border-radius:5px;margin:15px 0;'>";
+        echo "<strong>Nächste Schritte:</strong><br>";
+        echo "1. E-Mail im Posteingang prüfen (auch Spam-Ordner)<br>";
+        echo "2. Login-Code verwenden: <a href='/einfachlernen/login.php' target='_blank'>Zum Login</a><br>";
+        echo "3. Bei Problemen: info@einfachlernen.jetzt kontaktieren";
+        echo "</div>";
     } else {
-        echo "<h2 style='color:red'>❌ Email Sending Failed</h2>";
-        echo "<p><strong>Recipient:</strong> " . htmlspecialchars($cust['email']) . "</p>";
+        echo "<h2 style='color:red'>❌ E-Mail Versand fehlgeschlagen</h2>";
+        echo "<p><strong>Empfänger:</strong> " . htmlspecialchars($cust['email']) . "</p>";
         $error = error_get_last();
-        echo "<p><strong>Error:</strong> " . ($error['message'] ?? 'Unknown mail error') . "</p>";
+        if($error){
+            echo "<p><strong>Fehlermeldung:</strong> " . htmlspecialchars($error['message']) . "</p>";
+        }
         echo "<p><strong>Server:</strong> " . $_SERVER['SERVER_NAME'] . "</p>";
+        echo "<div style='background:#f8d7da;padding:15px;border-radius:5px;margin:15px 0;'>";
+        echo "Mögliche Ursachen:<br>";
+        echo "1. Server blockiert den Mailversand<br>";
+        echo "2. Ungültige Empfängeradresse<br>";
+        echo "3. Spamfilter hat die E-Mail abgelehnt";
+        echo "</div>";
         echo "<p><a href='dashboard.php?error=" . urlencode('Email sending failed') . "'>← Back to Dashboard</a></p>";
     }
     exit;

--- a/admin/test_mail.php
+++ b/admin/test_mail.php
@@ -7,16 +7,29 @@ echo "<h2>World4you mail() Test</h2>";
 if($_SERVER['REQUEST_METHOD'] === 'POST') {
     $test_email = $_POST['test_email'] ?? 'marcus@einfachstarten.jetzt';
     
-    $subject = 'Test Email from Anna Braun CMS';
-    $message = "This is a test email sent at " . date('Y-m-d H:i:s') . "\n\n";
-    $message .= "If you receive this, mail() function is working correctly.\n\n";
-    $message .= "Server: " . $_SERVER['SERVER_NAME'] . "\n";
-    $message .= "PHP Version: " . phpversion();
-    
-    $headers = 'From: Anna Braun Test <noreply@einfachstarten.jetzt>' . "\r\n" .
+    $subject = 'Test-E-Mail von Anna Braun Lerncoaching';
+    $message = "Liebe/r Tester/in,\n\n";
+    $message .= "diese Test-E-Mail wurde erfolgreich versendet.\n\n";
+    $message .= "📧 Zeitpunkt: " . date('d.m.Y um H:i:s') . " Uhr\n";
+    $message .= "🖥️ Server: " . $_SERVER['SERVER_NAME'] . "\n";
+    $message .= "🐘 PHP Version: " . phpversion() . "\n\n";
+    $message .= "Falls Sie diese E-Mail erhalten, funktioniert das E-Mail-System korrekt.\n\n";
+    $message .= "Mit freundlichen Grüßen\n";
+    $message .= "Anna Braun Lerncoaching System";
+
+    $headers = 'From: Anna Braun Lerncoaching <info@einfachlernen.jetzt>' . "\r\n" .
                'Reply-To: info@einfachlernen.jetzt' . "\r\n" .
-               'X-Mailer: PHP/' . phpversion();
-    
+               'Return-Path: info@einfachlernen.jetzt' . "\r\n" .
+               'Message-ID: <' . uniqid() . '.' . time() . '@einfachlernen.jetzt>' . "\r\n" .
+               'Date: ' . date('r') . "\r\n" .
+               'X-Mailer: Anna Braun CMS v1.0' . "\r\n" .
+               'X-Priority: 3 (Normal)' . "\r\n" .
+               'Importance: Normal' . "\r\n" .
+               'Content-Type: text/plain; charset=UTF-8' . "\r\n" .
+               'Content-Transfer-Encoding: 8bit' . "\r\n" .
+               'MIME-Version: 1.0' . "\r\n" .
+               'Organization: Anna Braun Lerncoaching';
+
     $result = mail($test_email, $subject, $message, $headers);
     
     if($result) {


### PR DESCRIPTION
## Summary
- add UTF-8 handling and detailed, branded PIN email content
- upgrade test mail script to share professional headers and German messaging
- improve debugging info and note future rate limiting

## Testing
- `php -l admin/send_pin.php`
- `php -l admin/test_mail.php`

------
https://chatgpt.com/codex/tasks/task_e_68bbe6e164ec8323bbd748aa98665f9c