### PR TITLE
Add customer activity tracking framework

### DIFF
--- a/admin/ActivityLogger.php
+++ b/admin/ActivityLogger.php
@@ -1,0 +1,137 @@
+<?php
+class ActivityLogger {
+    private $pdo;
+    
+    public function __construct($pdo) {
+        $this->pdo = $pdo;
+    }
+    
+    /**
+     * Log customer activity
+     * @param int $customer_id
+     * @param string $activity_type
+     * @param array $activity_data
+     * @param string $session_id
+     */
+    public function logActivity($customer_id, $activity_type, $activity_data = [], $session_id = null) {
+        try {
+            $stmt = $this->pdo->prepare("
+                INSERT INTO customer_activities 
+                (customer_id, activity_type, activity_data, ip_address, user_agent, session_id) 
+                VALUES (?, ?, ?, ?, ?, ?)
+            ");
+            
+            $stmt->execute([
+                $customer_id,
+                $activity_type,
+                json_encode($activity_data),
+                $this->getClientIP(),
+                $this->getUserAgent(),
+                $session_id ?: session_id()
+            ]);
+            
+            return $this->pdo->lastInsertId();
+        } catch (Exception $e) {
+            // Log error but don't break user experience
+            error_log("Activity tracking failed: " . $e->getMessage());
+            return false;
+        }
+    }
+    
+    /**
+     * Get customer activity history
+     */
+    public function getCustomerActivities($customer_id, $limit = 50, $activity_type = null) {
+        $sql = "SELECT * FROM customer_activities WHERE customer_id = ?";
+        $params = [$customer_id];
+        
+        if ($activity_type) {
+            $sql .= " AND activity_type = ?";
+            $params[] = $activity_type;
+        }
+        
+        $sql .= " ORDER BY created_at DESC LIMIT ?";
+        $params[] = $limit;
+        
+        $stmt = $this->pdo->prepare($sql);
+        $stmt->execute($params);
+        
+        return $stmt->fetchAll(PDO::FETCH_ASSOC);
+    }
+    
+    /**
+     * Get activity statistics for admin
+     */
+    public function getActivityStats($days = 30) {
+        $stmt = $this->pdo->prepare("
+            SELECT 
+                activity_type,
+                COUNT(*) as count,
+                COUNT(DISTINCT customer_id) as unique_customers,
+                DATE(created_at) as activity_date
+            FROM customer_activities 
+            WHERE created_at >= DATE_SUB(NOW(), INTERVAL ? DAY)
+            GROUP BY activity_type, DATE(created_at)
+            ORDER BY activity_date DESC, count DESC
+        ");
+        
+        $stmt->execute([$days]);
+        return $stmt->fetchAll(PDO::FETCH_ASSOC);
+    }
+    
+    /**
+     * Get most active customers
+     */
+    public function getTopActiveCustomers($days = 30, $limit = 10) {
+        $stmt = $this->pdo->prepare("
+            SELECT 
+                c.email,
+                c.first_name,
+                c.last_name,
+                COUNT(ca.id) as activity_count,
+                MAX(ca.created_at) as last_activity
+            FROM customers c
+            LEFT JOIN customer_activities ca ON c.id = ca.customer_id
+            WHERE ca.created_at >= DATE_SUB(NOW(), INTERVAL ? DAY)
+            GROUP BY c.id
+            ORDER BY activity_count DESC
+            LIMIT ?
+        ");
+        
+        $stmt->execute([$days, $limit]);
+        return $stmt->fetchAll(PDO::FETCH_ASSOC);
+    }
+    
+    /**
+     * Clean up old activities (privacy compliance)
+     */
+    public function cleanupOldActivities($days = 365) {
+        $stmt = $this->pdo->prepare("
+            DELETE FROM customer_activities 
+            WHERE created_at < DATE_SUB(NOW(), INTERVAL ? DAY)
+        ");
+        
+        return $stmt->execute([$days]);
+    }
+    
+    private function getClientIP() {
+        $ip_keys = ['HTTP_X_FORWARDED_FOR', 'HTTP_X_REAL_IP', 'HTTP_CLIENT_IP', 'REMOTE_ADDR'];
+        
+        foreach ($ip_keys as $key) {
+            if (!empty($_SERVER[$key])) {
+                $ip = $_SERVER[$key];
+                if (strpos($ip, ',') !== false) {
+                    $ip = explode(',', $ip)[0];
+                }
+                return trim($ip);
+            }
+        }
+        
+        return $_SERVER['REMOTE_ADDR'] ?? 'unknown';
+    }
+    
+    private function getUserAgent() {
+        return $_SERVER['HTTP_USER_AGENT'] ?? 'unknown';
+    }
+}
+?>

--- a/admin/analytics.php
+++ b/admin/analytics.php
@@ -1,0 +1,82 @@
+<?php
+session_start();
+if(empty($_SESSION['admin'])){header('Location: login.php');exit;}
+
+function getPDO(){
+    $config = require __DIR__ . '/config.php';
+    try{
+        return new PDO(
+            "mysql:host={$config['DB_HOST']};dbname={$config['DB_NAME']};charset=utf8mb4",
+            $config['DB_USER'],
+            $config['DB_PASS'],
+            [PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION]
+        );
+    }catch(PDOException $e){
+        die('DB connection failed: '.htmlspecialchars($e->getMessage()));
+    }
+}
+
+require_once 'ActivityLogger.php';
+$pdo = getPDO();
+$logger = new ActivityLogger($pdo);
+
+$days = $_GET['days'] ?? 30;
+$stats = $logger->getActivityStats($days);
+$top_customers = $logger->getTopActiveCustomers($days);
+
+echo "<h1>Customer Activity Analytics</h1>";
+echo "<nav><a href='dashboard.php'>← Back to Dashboard</a></nav>";
+
+echo "<div style='margin: 20px 0;'>";
+echo "<label>Time Period: </label>";
+echo "<select onchange='window.location.href=\"?days=\" + this.value'>";
+$periods = [7 => '7 days', 30 => '30 days', 90 => '90 days', 365 => '1 year'];
+foreach ($periods as $value => $label) {
+    $selected = ($days == $value) ? 'selected' : '';
+    echo "<option value='$value' $selected>$label</option>";
+}
+echo "</select>";
+echo "</div>";
+
+// Activity Statistics
+echo "<h2>Activity Overview (Last $days days)</h2>";
+echo "<table border='1' cellpadding='10' style='border-collapse: collapse; width: 100%;'>";
+echo "<tr><th>Activity Type</th><th>Total Events</th><th>Unique Customers</th><th>Avg per Day</th></tr>";
+
+$activity_totals = [];
+foreach ($stats as $stat) {
+    $type = $stat['activity_type'];
+    if (!isset($activity_totals[$type])) {
+        $activity_totals[$type] = ['count' => 0, 'customers' => []];
+    }
+    $activity_totals[$type]['count'] += $stat['count'];
+    $activity_totals[$type]['customers'][] = $stat['unique_customers'];
+}
+
+foreach ($activity_totals as $type => $data) {
+    $avg_per_day = round($data['count'] / $days, 1);
+    $unique_customers = max($data['customers']);
+    echo "<tr>";
+    echo "<td>" . ucfirst(str_replace('_', ' ', $type)) . "</td>";
+    echo "<td>{$data['count']}</td>";
+    echo "<td>$unique_customers</td>";
+    echo "<td>$avg_per_day</td>";
+    echo "</tr>";
+}
+echo "</table>";
+
+// Top Active Customers
+echo "<h2>Most Active Customers (Last $days days)</h2>";
+echo "<table border='1' cellpadding='10' style='border-collapse: collapse; width: 100%;'>";
+echo "<tr><th>Customer</th><th>Email</th><th>Activities</th><th>Last Activity</th></tr>";
+
+foreach ($top_customers as $customer) {
+    echo "<tr>";
+    echo "<td>{$customer['first_name']} {$customer['last_name']}</td>";
+    echo "<td>{$customer['email']}</td>";
+    echo "<td>{$customer['activity_count']}</td>";
+    echo "<td>" . date('Y-m-d H:i', strtotime($customer['last_activity'])) . "</td>";
+    echo "</tr>";
+}
+echo "</table>";
+?>

--- a/admin/migrate.php
+++ b/admin/migrate.php
@@ -73,6 +73,33 @@ try {
     } catch (PDOException $e) {
         echo "<p style='color:red'>❌ customer_sessions creation failed: " . htmlspecialchars($e->getMessage()) . "</p>";
     }
+
+    // Create customer_activities table if not exists
+    echo "<h3>Creating customer_activities table:</h3>";
+    try {
+        $create_activities = "CREATE TABLE IF NOT EXISTS customer_activities (
+            id INT AUTO_INCREMENT PRIMARY KEY,
+            customer_id INT NOT NULL,
+            activity_type VARCHAR(50) NOT NULL,
+            activity_data JSON NULL,
+            ip_address VARCHAR(45) NULL,
+            user_agent TEXT NULL,
+            session_id VARCHAR(64) NULL,
+            created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+            FOREIGN KEY (customer_id) REFERENCES customers(id) ON DELETE CASCADE
+        )";
+        $pdo->exec($create_activities);
+
+        // Indexes for performance
+        $pdo->exec("CREATE INDEX idx_customer_activities_customer ON customer_activities(customer_id)");
+        $pdo->exec("CREATE INDEX idx_customer_activities_type ON customer_activities(activity_type)");
+        $pdo->exec("CREATE INDEX idx_customer_activities_date ON customer_activities(created_at)");
+        $pdo->exec("CREATE INDEX idx_customer_activities_customer_date ON customer_activities(customer_id, created_at)");
+
+        echo "<p style='color:green'>✅ customer_activities table ready</p>";
+    } catch (PDOException $e) {
+        echo "<p style='color:red'>❌ customer_activities creation failed: " . htmlspecialchars($e->getMessage()) . "</p>";
+    }
     
     // Verify final schema
     echo "<h3>Final Schema Verification:</h3>";

--- a/customer/index.php
+++ b/customer/index.php
@@ -17,7 +17,15 @@ if(isset($_SESSION['customer_last_activity']) && (time() - $_SESSION['customer_l
     exit;
 }
 
-if(isset($_GET['logout'])){
+if(isset($_GET['logout']) && !empty($_SESSION['customer'])){
+    require_once __DIR__ . '/../admin/ActivityLogger.php';
+    $pdo = getPDO();
+    $logger = new ActivityLogger($pdo);
+    $logger->logActivity($_SESSION['customer']['id'], 'logout', [
+        'logout_method' => 'manual',
+        'session_duration' => time() - ($_SESSION['customer_login_time'] ?? time())
+    ]);
+
     $_SESSION = [];
     if (ini_get('session.use_cookies')) {
         $params = session_get_cookie_params();


### PR DESCRIPTION
## Summary
- add `ActivityLogger` utility with methods to record customer events, stats, and cleanup
- store activity data via new `customer_activities` table and indexes
- log login, logout, and PIN request events; expose analytics and per-customer activity views

## Testing
- `php -l admin/ActivityLogger.php`
- `php -l admin/migrate.php`
- `php -l login.php`
- `php -l customer/index.php`
- `php -l admin/send_pin.php`
- `php -l admin/analytics.php`
- `php -l admin/dashboard.php`


------
https://chatgpt.com/codex/tasks/task_e_68bc17bd786483238d01335b6c4b7c2b