### PR TITLE
Add debugging to analytics page and improve activity queries

### DIFF
--- a/admin/ActivityLogger.php
+++ b/admin/ActivityLogger.php
@@ -63,28 +63,42 @@ class ActivityLogger {
      * Get activity statistics for admin
      */
     public function getActivityStats($days = 30) {
-        $stmt = $this->pdo->prepare("
-            SELECT 
+        echo "<p>Debug: Getting activity stats for $days days</p>";
+
+        try {
+            $stmt = $this->pdo->prepare("
+            SELECT
                 activity_type,
                 COUNT(*) as count,
                 COUNT(DISTINCT customer_id) as unique_customers,
                 DATE(created_at) as activity_date
-            FROM customer_activities 
+            FROM customer_activities
             WHERE created_at >= DATE_SUB(NOW(), INTERVAL ? DAY)
             GROUP BY activity_type, DATE(created_at)
             ORDER BY activity_date DESC, count DESC
         ");
-        
-        $stmt->execute([$days]);
-        return $stmt->fetchAll(PDO::FETCH_ASSOC);
+
+            $stmt->execute([$days]);
+            $result = $stmt->fetchAll(PDO::FETCH_ASSOC);
+
+            echo "<p>Debug: Found " . count($result) . " activity records</p>";
+            return $result;
+
+        } catch (PDOException $e) {
+            echo "<p style='color:red'>SQL Error in getActivityStats: " . htmlspecialchars($e->getMessage()) . "</p>";
+            return [];
+        }
     }
     
     /**
      * Get most active customers
      */
     public function getTopActiveCustomers($days = 30, $limit = 10) {
-        $stmt = $this->pdo->prepare("
-            SELECT 
+        echo "<p>Debug: Getting top active customers for $days days</p>";
+
+        try {
+            $stmt = $this->pdo->prepare("
+            SELECT
                 c.email,
                 c.first_name,
                 c.last_name,
@@ -93,13 +107,21 @@ class ActivityLogger {
             FROM customers c
             LEFT JOIN customer_activities ca ON c.id = ca.customer_id
             WHERE ca.created_at >= DATE_SUB(NOW(), INTERVAL ? DAY)
-            GROUP BY c.id
+            GROUP BY c.id, c.email, c.first_name, c.last_name
             ORDER BY activity_count DESC
             LIMIT ?
         ");
-        
-        $stmt->execute([$days, $limit]);
-        return $stmt->fetchAll(PDO::FETCH_ASSOC);
+
+            $stmt->execute([$days, $limit]);
+            $result = $stmt->fetchAll(PDO::FETCH_ASSOC);
+
+            echo "<p>Debug: Found " . count($result) . " active customers</p>";
+            return $result;
+
+        } catch (PDOException $e) {
+            echo "<p style='color:red'>SQL Error in getTopActiveCustomers: " . htmlspecialchars($e->getMessage()) . "</p>";
+            return [];
+        }
     }
     
     /**

--- a/admin/analytics.php
+++ b/admin/analytics.php
@@ -1,28 +1,118 @@
 <?php
-session_start();
-if(empty($_SESSION['admin'])){header('Location: login.php');exit;}
+// Enable error reporting for debugging
+error_reporting(E_ALL);
+ini_set('display_errors', 1);
+ini_set('log_errors', 1);
 
-function getPDO(){
+echo "<h1>Analytics Debug Mode</h1>";
+echo "<p>Starting analytics page load...</p>";
+
+session_start();
+if (empty($_SESSION['admin'])) {
+    echo "<p>Redirecting to login...</p>";
+    header('Location: login.php');
+    exit;
+}
+echo "<p>✅ Admin session verified</p>";
+
+function getPDO()
+{
+    echo "<p>Debug: Connecting to database...</p>";
     $config = require __DIR__ . '/config.php';
-    try{
-        return new PDO(
+    try {
+        $pdo = new PDO(
             "mysql:host={$config['DB_HOST']};dbname={$config['DB_NAME']};charset=utf8mb4",
             $config['DB_USER'],
             $config['DB_PASS'],
             [PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION]
         );
-    }catch(PDOException $e){
-        die('DB connection failed: '.htmlspecialchars($e->getMessage()));
+        echo "<p>✅ Database connected successfully</p>";
+        return $pdo;
+    } catch (PDOException $e) {
+        echo "<p style='color:red'>❌ DB connection failed: " . htmlspecialchars($e->getMessage()) . "</p>";
+        die('Database connection failed');
     }
 }
 
+$activityLoggerPath = __DIR__ . '/ActivityLogger.php';
+if (!file_exists($activityLoggerPath)) {
+    die("❌ ActivityLogger.php not found at: $activityLoggerPath");
+}
+if (!is_readable($activityLoggerPath)) {
+    die("❌ ActivityLogger.php not readable at: $activityLoggerPath");
+}
+echo "<p>✅ ActivityLogger.php found and readable</p>";
+echo "<p>Debug: Including ActivityLogger...</p>";
 require_once 'ActivityLogger.php';
+
+echo "<p>Debug: Creating PDO connection...</p>";
 $pdo = getPDO();
+
+echo "<p>Debug: Creating ActivityLogger instance...</p>";
 $logger = new ActivityLogger($pdo);
 
+// Add test logging capability
+if (isset($_GET['test_activity'])) {
+    echo "<h3>Testing Activity Logging</h3>";
+
+    // Find a customer to test with
+    $test_customer = $pdo->query("SELECT id FROM customers LIMIT 1")->fetchColumn();
+
+    if ($test_customer) {
+        $logger->logActivity($test_customer, 'test_activity', [
+            'test_source' => 'analytics_debug',
+            'timestamp' => date('Y-m-d H:i:s')
+        ]);
+        echo "<p style='color:green'>✅ Test activity logged for customer $test_customer</p>";
+        echo "<p><a href='analytics.php'>Refresh Analytics</a></p>";
+    } else {
+        echo "<p style='color:red'>❌ No customers found to test with</p>";
+    }
+    exit;
+}
+
 $days = $_GET['days'] ?? 30;
+echo "<p>Debug: Getting stats for $days days...</p>";
+
+echo "<p>Debug: Calling getActivityStats...</p>";
 $stats = $logger->getActivityStats($days);
+
+echo "<p>Debug: Calling getTopActiveCustomers...</p>";
 $top_customers = $logger->getTopActiveCustomers($days);
+
+echo "<p>Debug: Stats count: " . count($stats) . "</p>";
+echo "<p>Debug: Top customers count: " . count($top_customers) . "</p>";
+
+// Add test query to verify data exists
+echo "<h3>Debug: Raw Data Check</h3>";
+try {
+    $test_stmt = $pdo->query("SELECT COUNT(*) as total FROM customer_activities");
+    $total_activities = $test_stmt->fetchColumn();
+    echo "<p>Total activities in database: $total_activities</p>";
+
+    $recent_stmt = $pdo->query("SELECT * FROM customer_activities ORDER BY created_at DESC LIMIT 5");
+    $recent = $recent_stmt->fetchAll(PDO::FETCH_ASSOC);
+    echo "<p>Recent activities:</p>";
+    echo "<pre>" . print_r($recent, true) . "</pre>";
+} catch (Exception $e) {
+    echo "<p style='color:red'>Test query failed: " . htmlspecialchars($e->getMessage()) . "</p>";
+}
+
+// Add fallback for empty results
+if (empty($stats) && empty($top_customers)) {
+    echo "<div style='background:#fff3cd;padding:1rem;margin:1rem 0;'>";
+    echo "<h3>⚠️ No Analytics Data Found</h3>";
+    echo "<p>Possible causes:</p>";
+    echo "<ul>";
+    echo "<li>No customer activities in the selected time period</li>";
+    echo "<li>Database query issues</li>";
+    echo "<li>Date range too restrictive</li>";
+    echo "</ul>";
+    echo "<p>Try selecting a longer time period or check if activities are being logged.</p>";
+    echo "</div>";
+}
+
+echo "<p><a href='?test_activity=1'>🧪 Test Activity Logging</a></p>";
 
 echo "<h1>Customer Activity Analytics</h1>";
 echo "<nav><a href='dashboard.php'>← Back to Dashboard</a></nav>";
@@ -79,4 +169,6 @@ foreach ($top_customers as $customer) {
     echo "</tr>";
 }
 echo "</table>";
+
 ?>
+


### PR DESCRIPTION
## Summary
- add comprehensive error reporting and debug output to `admin/analytics.php`
- add runtime diagnostics and query hardening in `ActivityLogger` methods
- include test activity trigger and fallback message when no data is available

## Testing
- `php -l admin/ActivityLogger.php`
- `php -l admin/analytics.php`


------
https://chatgpt.com/codex/tasks/task_e_68bc1b23bba08323b06144967807c784