### PR TITLE
Debug customer activity view in dashboard

### DIFF
--- a/admin/ActivityLogger.php
+++ b/admin/ActivityLogger.php
@@ -51,12 +51,18 @@ class ActivityLogger {
         }
         
         $sql .= " ORDER BY created_at DESC LIMIT ?";
-        $params[] = $limit;
-        
-        $stmt = $this->pdo->prepare($sql);
-        $stmt->execute($params);
-        
-        return $stmt->fetchAll(PDO::FETCH_ASSOC);
+        $params[] = (int)$limit;  // Ensure limit is integer
+
+        try {
+            $stmt = $this->pdo->prepare($sql);
+            $stmt->execute($params);
+            $result = $stmt->fetchAll(PDO::FETCH_ASSOC);
+
+            return $result;
+        } catch (PDOException $e) {
+            error_log("getCustomerActivities error: " . $e->getMessage());
+            return [];
+        }
     }
     
     /**


### PR DESCRIPTION
## Summary
- Add detailed debugging section for `view_activity` requests on the admin dashboard
- Enhance activity table rendering with error handling and context messaging
- Harden `ActivityLogger::getCustomerActivities` with integer limit casting and exception handling

## Testing
- `php -l admin/ActivityLogger.php`
- `php -l admin/dashboard.php`


------
https://chatgpt.com/codex/tasks/task_e_68bc1de0cb5c83238caf48661cc51e1a