### PR TITLE
Fix getCustomerActivities LIMIT binding and remove dashboard debug

### DIFF
--- a/admin/ActivityLogger.php
+++ b/admin/ActivityLogger.php
@@ -42,23 +42,27 @@ class ActivityLogger {
      * Get customer activity history
      */
     public function getCustomerActivities($customer_id, $limit = 50, $activity_type = null) {
+        // Ensure limit is integer and safe
+        $limit = (int)$limit;
+        if ($limit < 1 || $limit > 1000) {
+            $limit = 50; // Default fallback
+        }
+
         $sql = "SELECT * FROM customer_activities WHERE customer_id = ?";
         $params = [$customer_id];
-        
+
         if ($activity_type) {
             $sql .= " AND activity_type = ?";
             $params[] = $activity_type;
         }
-        
-        $sql .= " ORDER BY created_at DESC LIMIT ?";
-        $params[] = (int)$limit;  // Ensure limit is integer
+
+        // Use string interpolation for LIMIT since PDO can't parameterize it properly
+        $sql .= " ORDER BY created_at DESC LIMIT {$limit}";
 
         try {
             $stmt = $this->pdo->prepare($sql);
             $stmt->execute($params);
-            $result = $stmt->fetchAll(PDO::FETCH_ASSOC);
-
-            return $result;
+            return $stmt->fetchAll(PDO::FETCH_ASSOC);
         } catch (PDOException $e) {
             error_log("getCustomerActivities error: " . $e->getMessage());
             return [];

--- a/admin/dashboard.php
+++ b/admin/dashboard.php
@@ -104,64 +104,6 @@ unset($c);
 </table>
 
 <?php
-// ADD DEBUGGING FOR VIEW_ACTIVITY
-if (isset($_GET['view_activity'])) {
-    echo "<div style='background:#e7f3ff;padding:1rem;margin:1rem 0;border:1px solid #0066cc;'>";
-    echo "<h3>🔍 Debug: View Activity Request</h3>";
-    echo "<p><strong>view_activity parameter:</strong> " . htmlspecialchars($_GET['view_activity']) . "</p>";
-    echo "<p><strong>Is numeric:</strong> " . (is_numeric($_GET['view_activity']) ? 'YES' : 'NO') . "</p>";
-
-    if (is_numeric($_GET['view_activity'])) {
-        $customer_id = (int)$_GET['view_activity'];
-        echo "<p><strong>Customer ID (cast):</strong> $customer_id</p>";
-
-        echo "<p>Attempting to load ActivityLogger...</p>";
-        try {
-            require_once 'ActivityLogger.php';
-            echo "<p>✅ ActivityLogger loaded successfully</p>";
-
-            $logger = new ActivityLogger($pdo);
-            echo "<p>✅ ActivityLogger instance created</p>";
-
-            echo "<p>Calling getCustomerActivities($customer_id, 20)...</p>";
-            $activities = $logger->getCustomerActivities($customer_id, 20);
-
-            echo "<p><strong>Activities found:</strong> " . count($activities) . "</p>";
-
-            if (empty($activities)) {
-                echo "<p style='color:orange'>⚠️ No activities found for customer $customer_id</p>";
-
-                // Check if customer exists
-                $check_customer = $pdo->prepare("SELECT first_name, last_name, email FROM customers WHERE id = ?");
-                $check_customer->execute([$customer_id]);
-                $customer_info = $check_customer->fetch(PDO::FETCH_ASSOC);
-
-                if ($customer_info) {
-                    echo "<p>Customer exists: " . htmlspecialchars($customer_info['first_name'] . ' ' . $customer_info['last_name']) . " (" . htmlspecialchars($customer_info['email']) . ")</p>";
-
-                    // Check activities in database
-                    $check_activities = $pdo->prepare("SELECT COUNT(*) FROM customer_activities WHERE customer_id = ?");
-                    $check_activities->execute([$customer_id]);
-                    $activity_count = $check_activities->fetchColumn();
-                    echo "<p>Raw activity count in DB: $activity_count</p>";
-                } else {
-                    echo "<p style='color:red'>❌ Customer $customer_id does not exist</p>";
-                }
-            } else {
-                echo "<p style='color:green'>✅ Activities loaded successfully</p>";
-                echo "<pre>" . print_r(array_slice($activities, 0, 2), true) . "</pre>";
-            }
-
-        } catch (Exception $e) {
-            echo "<p style='color:red'>❌ Error: " . htmlspecialchars($e->getMessage()) . "</p>";
-            echo "<p>Stack trace: " . htmlspecialchars($e->getTraceAsString()) . "</p>";
-        }
-    } else {
-        echo "<p style='color:red'>❌ view_activity parameter is not numeric</p>";
-    }
-    echo "</div>";
-}
-
 // ORIGINAL VIEW_ACTIVITY CODE (keep existing but add error handling)
 if (isset($_GET['view_activity']) && is_numeric($_GET['view_activity'])) {
     echo "<div style='margin-top:2rem;'>";


### PR DESCRIPTION
## Summary
- Fix `getCustomerActivities` to handle LIMIT safely without PDO binding issues
- Remove temporary debug output from admin dashboard activity view

## Testing
- `php -l admin/ActivityLogger.php`
- `php -l admin/dashboard.php`


------
https://chatgpt.com/codex/tasks/task_e_68bc1fb79c508323bb95509fbdb7da53