### PR TITLE
Fix customer dashboard link to secure Termine system

### DIFF
--- a/customer/index.php
+++ b/customer/index.php
@@ -759,7 +759,7 @@ if(!empty($_SESSION['customer'])) {
                         </div>
                     </a>
                     
-                    <a href="../termine.html?email=<?= urlencode($customer['email']) ?>" class="action-card">
+                    <a href="termine.php" class="action-card">
                         <div class="action-icon">📋</div>
                         <div class="action-content">
                             <h3>Meine Termine</h3>


### PR DESCRIPTION
## Summary
- direct "Meine Termine" button to new session-authenticated `termine.php`

## Testing
- `php -l customer/index.php`
- `php -l calendly_api.php`


------
https://chatgpt.com/codex/tasks/task_e_68bc337e9c488323b12d05c84e6f3c0a