### PR TITLE
Fix slot search activity tracking and add booking click logging

### DIFF
--- a/admin/analytics.php
+++ b/admin/analytics.php
@@ -29,6 +29,26 @@ $days = $_GET['days'] ?? 30;
 $stats = $logger->getActivityStats($days);
 $top_customers = $logger->getTopActiveCustomers($days);
 
+$activity_descriptions = [
+    'login' => 'Login (PIN)',
+    'login_failed' => 'Login Failed',
+    'logout' => 'Logout',
+    'pin_request' => 'PIN Requested',
+    'session_timeout' => 'Session Timeout',
+    'dashboard_accessed' => 'Dashboard Accessed',
+    'profile_refreshed' => 'Profile Refreshed',
+    'page_view' => 'Page View',
+    'slots_api_called' => 'Slot Search API',
+    'service_viewed' => 'Service Viewed',
+    'availability_checked' => 'Availability Checked',
+    'slots_found' => 'Slots Found',
+    'slots_not_found' => 'No Slots Available',
+    'slot_search_failed' => 'Slot Search Error',
+    'booking_initiated' => 'Real Booking Started',
+    'booking_completed' => 'Booking Confirmed',
+    'booking_failed' => 'Booking Failed'
+];
+
 echo "<h1>Customer Activity Analytics</h1>";
 echo "<nav><a href='dashboard.php'>← Back to Dashboard</a></nav>";
 
@@ -63,8 +83,9 @@ if (empty($stats)) {
     foreach ($activity_totals as $type => $data) {
         $avg_per_day = round($data['count'] / $days, 1);
         $unique_customers = max($data['customers']);
+        $display_name = $activity_descriptions[$type] ?? ucfirst(str_replace('_', ' ', $type));
         echo "<tr>";
-        echo "<td>" . ucfirst(str_replace('_', ' ', $type)) . "</td>";
+        echo "<td>{$display_name}</td>";
         echo "<td>{$data['count']}</td>";
         echo "<td>$unique_customers</td>";
         echo "<td>$avg_per_day</td>";

--- a/customer/booking_tracking.php
+++ b/customer/booking_tracking.php
@@ -1,0 +1,30 @@
+<?php
+// Helper functions for booking tracking activities
+
+function logBookingInitiated($customer_id, $service_slug, $calendly_url) {
+    require_once __DIR__ . '/../admin/ActivityLogger.php';
+    $pdo = getPDO();
+    $logger = new ActivityLogger($pdo);
+
+    $logger->logActivity($customer_id, 'booking_initiated', [
+        'service_slug' => $service_slug,
+        'calendly_url' => $calendly_url,
+        'booking_method' => 'calendly_redirect',
+        'real_booking_start' => true
+    ]);
+}
+
+function logBookingCompleted($customer_id, $service_slug, $booking_details) {
+    require_once __DIR__ . '/../admin/ActivityLogger.php';
+    $pdo = getPDO();
+    $logger = new ActivityLogger($pdo);
+
+    $logger->logActivity($customer_id, 'booking_completed', [
+        'service_slug' => $service_slug,
+        'booking_confirmed' => true,
+        'calendly_event_id' => $booking_details['event_id'] ?? null,
+        'scheduled_time' => $booking_details['scheduled_time'] ?? null,
+        'real_booking_completion' => true
+    ]);
+}
+?>

--- a/customer/termine-suchen.php
+++ b/customer/termine-suchen.php
@@ -489,7 +489,7 @@ logPageView($customer['id'], 'termine_suchen', [
             }
             
             updateProgress(100, 100, 'Termine gefunden!');
-            setTimeout(() => showResults(allSlots, count), 500);
+            setTimeout(() => showResults(allSlots, count, service), 500);
         }
 
         function updateProgress(current, max, text) {
@@ -498,7 +498,7 @@ logPageView($customer['id'], 'termine_suchen', [
             document.getElementById('progressText').textContent = text;
         }
 
-        function showResults(slots, targetCount) {
+        function showResults(slots, targetCount, serviceSlug) {
             const container = document.getElementById('slotsContainer');
             const resultsSection = document.getElementById('resultsSection');
             
@@ -521,7 +521,7 @@ logPageView($customer['id'], 'termine_suchen', [
                     </div>
                 ` + slots.map(daySlot => {
                     const timeButtons = daySlot.slots.map(slot => {
-                        return `<a href="${slot.booking_url}" target="_blank" class="time-button">
+                        return `<a href="#" onclick="trackBookingClick('${serviceSlug}', '${slot.booking_url}')" class="time-button">
                             ${slot.time_only} Uhr
                         </a>`;
                     }).join('');
@@ -539,6 +539,22 @@ logPageView($customer['id'], 'termine_suchen', [
             }
             
             resultsSection.style.display = 'block';
+        }
+
+        function trackBookingClick(serviceSlug, calendlyUrl) {
+            fetch('track_booking.php', {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/json',
+                },
+                body: JSON.stringify({
+                    action: 'booking_initiated',
+                    service_slug: serviceSlug,
+                    calendly_url: calendlyUrl
+                })
+            });
+
+            window.open(calendlyUrl, '_blank');
         }
 
         function showError(message) {

--- a/customer/track_booking.php
+++ b/customer/track_booking.php
@@ -1,0 +1,27 @@
+<?php
+require __DIR__.'/auth.php';
+require __DIR__.'/booking_tracking.php';
+$customer = require_customer_login();
+
+header('Content-Type: application/json');
+
+if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+    http_response_code(405);
+    echo json_encode(['error' => 'Method not allowed']);
+    exit;
+}
+
+$input = json_decode(file_get_contents('php://input'), true);
+
+if ($input['action'] === 'booking_initiated') {
+    logBookingInitiated(
+        $customer['id'],
+        $input['service_slug'] ?? 'unknown',
+        $input['calendly_url'] ?? ''
+    );
+
+    echo json_encode(['success' => true]);
+} else {
+    echo json_encode(['error' => 'Invalid action']);
+}
+?>


### PR DESCRIPTION
## Summary
- Correct slot search logging to use new availability and slot result activity types
- Track real booking attempts via new track_booking endpoint and frontend hook
- Expand admin analytics with descriptions for new activity types

## Testing
- `php -l customer/slots_api.php`
- `php -l customer/booking_tracking.php`
- `php -l customer/track_booking.php`
- `php -l customer/termine-suchen.php`
- `php -l admin/analytics.php`


------
https://chatgpt.com/codex/tasks/task_e_68bc462f48a483238028d1c3ec18cbf3