### PR TITLE
Improve iOS Safari session handling

### DIFF
--- a/customer/debug_session.php
+++ b/customer/debug_session.php
@@ -1,0 +1,21 @@
+<?php
+require __DIR__.'/auth.php';
+
+header('Content-Type: application/json');
+
+$debug_info = [
+    'timestamp' => date('Y-m-d H:i:s'),
+    'user_agent' => $_SERVER['HTTP_USER_AGENT'] ?? 'unknown',
+    'is_ios' => strpos($_SERVER['HTTP_USER_AGENT'] ?? '', 'iPhone') !== false || strpos($_SERVER['HTTP_USER_AGENT'] ?? '', 'iPad') !== false,
+    'cookies' => $_COOKIE,
+    'session_data' => [
+        'customer_id' => $_SESSION['customer_id'] ?? null,
+        'customer_token' => isset($_SESSION['customer_token']) ? substr($_SESSION['customer_token'], 0, 10) . '...' : null,
+        'customer' => isset($_SESSION['customer']) ? 'set' : 'not set',
+        'session_id' => session_id()
+    ],
+    'current_customer' => get_current_customer() ? 'found' : 'not found'
+];
+
+echo json_encode($debug_info, JSON_PRETTY_PRINT);
+?>

--- a/customer/index.php
+++ b/customer/index.php
@@ -54,6 +54,23 @@ if(isset($_GET['logout']) && !empty($_SESSION['customer'])){
 
 $customer = require_customer_login();
 
+// iOS-specific session validation
+if (isset($_SESSION['ios_login_success']) && $_SESSION['ios_login_success']) {
+    error_log("iOS customer " . $customer['id'] . " successfully reached dashboard");
+    unset($_SESSION['ios_login_success']); // Clean up flag
+}
+
+// Additional validation for iOS
+$user_agent = $_SERVER['HTTP_USER_AGENT'] ?? '';
+$is_ios = strpos($user_agent, 'iPhone') !== false || strpos($user_agent, 'iPad') !== false;
+
+if ($is_ios && !isset($_COOKIE['customer_session']) && !isset($_SESSION['customer_token'])) {
+    error_log("iOS session problem detected - no cookie or session token");
+    // Force re-login with message
+    header('Location: ../login.php?error=' . urlencode('iOS Session-Problem erkannt. Bitte erneut einloggen.'));
+    exit;
+}
+
 // Log dashboard access
 require_once __DIR__ . '/../admin/ActivityLogger.php';
 $pdo = getPDO();


### PR DESCRIPTION
## Summary
- set session cookies with SameSite=Lax and store token in PHP session as fallback
- add iOS-aware login flow with JS redirect and debugging hooks
- validate iOS sessions on dashboard and expose debug endpoint

## Testing
- `php -l customer/auth.php`
- `php -l login.php`
- `php -l customer/index.php`
- `php -l customer/debug_session.php`


------
https://chatgpt.com/codex/tasks/task_e_68bc6a0794bc8323a4279dc101631d9e