### PR TITLE
Switch customer authentication to PHP sessions

### DIFF
--- a/customer/auth.php
+++ b/customer/auth.php
@@ -21,99 +21,84 @@ function cleanup_sessions($pdo){
 function create_customer_session($customer_id){
     $pdo = getPDO();
     cleanup_sessions($pdo);
+    
+    // Use standard PHP session instead of custom cookie
+    $_SESSION['customer_id'] = $customer_id;
+    $_SESSION['customer_login_time'] = time();
+    $_SESSION['customer_last_activity'] = time();
+    $_SESSION['session_authenticated'] = true;
+    
+    // Still store in database for security tracking
     $token = bin2hex(random_bytes(32));
     $expires = date('Y-m-d H:i:s', strtotime('+7 days'));
-
-    // Store in database
+    
     $stmt = $pdo->prepare('INSERT INTO customer_sessions (customer_id, session_token, expires_at) VALUES (?, ?, ?)');
     $stmt->execute([$customer_id, $token, $expires]);
-
-    // FIXED: iOS-compatible cookie settings
-    $secure = isset($_SERVER['HTTPS']) && $_SERVER['HTTPS'] !== 'off';
-    $sameSite = 'Lax'; // iOS Safari compatible
-
-    // Modern setcookie with all attributes
-    if (PHP_VERSION_ID >= 70300) {
-        // PHP 7.3+ supports SameSite attribute
-        setcookie('customer_session', $token, [
-            'expires' => time() + 7*24*3600,
-            'path' => '/einfachlernen/',
-            'domain' => '',
-            'secure' => $secure,
-            'httponly' => true,
-            'samesite' => $sameSite
-        ]);
-    } else {
-        // Fallback for older PHP versions
-        setcookie('customer_session', $token, time() + 7*24*3600, '/einfachlernen/; SameSite=' . $sameSite, '', $secure, true);
-    }
-
-    // ADDITIONAL: Also store in PHP session as fallback
-    $_SESSION['customer_token'] = $token;
-    $_SESSION['customer_id'] = $customer_id;
-
-    // Log cookie setting for debugging
-    error_log("Cookie set for customer $customer_id: token=" . substr($token, 0, 10) . "... secure=$secure sameSite=$sameSite");
+    
+    $_SESSION['db_session_token'] = $token;
+    
+    error_log("PHP Session created for customer $customer_id: session_id=" . session_id());
 }
-
 function get_current_customer(){
-    $pdo = getPDO();
-    cleanup_sessions($pdo);
-
-    // Try to get token from cookie first
-    $token = $_COOKIE['customer_session'] ?? null;
-
-    // FALLBACK: If no cookie token, try session token
-    if (!$token && isset($_SESSION['customer_token'])) {
-        $token = $_SESSION['customer_token'];
-        error_log("Using session token fallback for customer " . ($_SESSION['customer_id'] ?? 'unknown'));
-    }
-
-    if (!$token) {
+    // Check if authenticated via PHP session
+    if (empty($_SESSION['customer_id']) || empty($_SESSION['session_authenticated'])) {
         return null;
     }
-
-    $stmt = $pdo->prepare('SELECT c.* FROM customer_sessions s JOIN customers c ON c.id = s.customer_id WHERE s.session_token = ? AND s.expires_at > NOW()');
+    
+    $customer_id = $_SESSION['customer_id'];
+    
+    $pdo = getPDO();
+    
+    // Get fresh customer data from database
+    $stmt = $pdo->prepare('SELECT * FROM customers WHERE id = ?');
+    $stmt->execute([$customer_id]);
     $customer = $stmt->fetch(PDO::FETCH_ASSOC);
-
-    // If found via session token but cookie is missing, reset cookie
-    if ($customer && !isset($_COOKIE['customer_session']) && isset($_SESSION['customer_token'])) {
-        $secure = isset($_SERVER['HTTPS']) && $_SERVER['HTTPS'] !== 'off';
-        if (PHP_VERSION_ID >= 70300) {
-            setcookie('customer_session', $token, [
-                'expires' => time() + 7*24*3600,
-                'path' => '/einfachlernen/',
-                'domain' => '',
-                'secure' => $secure,
-                'httponly' => true,
-                'samesite' => 'Lax'
-            ]);
-        } else {
-            setcookie('customer_session', $token, time() + 7*24*3600, '/einfachlernen/; SameSite=Lax', '', $secure, true);
-        }
-        error_log("Cookie restored for customer " . $customer['id']);
+    
+    if (!$customer) {
+        // Customer not found in database - clear session
+        session_destroy();
+        return null;
     }
-
+    
+    // Update last activity
+    $_SESSION['customer_last_activity'] = time();
+    
     return $customer;
 }
 function require_customer_login(){
     $cust = get_current_customer();
     if(!$cust){
-        header('Location: ../login.php');
+        // Clear any partial session data
+        session_destroy();
+        header('Location: ../login.php?message=' . urlencode('Bitte melden Sie sich an.'));
         exit;
     }
     return $cust;
 }
 function destroy_customer_session(){
-    if(!empty($_COOKIE['customer_session'])){
-        $token = $_COOKIE['customer_session'];
+    // Clean up database session if exists
+    if (!empty($_SESSION['db_session_token'])) {
         $pdo = getPDO();
         $stmt = $pdo->prepare('DELETE FROM customer_sessions WHERE session_token = ?');
-        $stmt->execute([$token]);
-        setcookie('customer_session','',time()-3600,'/einfachlernen/', '', true, true);
+        $stmt->execute([$_SESSION['db_session_token']]);
     }
+    
+    // Clear PHP session
+    $_SESSION = [];
+    
+    // Destroy session cookie
+    if (ini_get('session.use_cookies')) {
+        $params = session_get_cookie_params();
+        setcookie(session_name(), '', time() - 42000,
+            $params['path'], $params['domain'],
+            $params['secure'], $params['httponly']
+        );
+    }
+    
+    session_destroy();
+    
+    error_log("Session destroyed successfully");
 }
-
 function logPageView($customer_id, $page_name, $additional_data = []) {
     require_once __DIR__ . '/../admin/ActivityLogger.php';
     $pdo = getPDO();

--- a/customer/debug_session.php
+++ b/customer/debug_session.php
@@ -7,14 +7,18 @@ $debug_info = [
     'timestamp' => date('Y-m-d H:i:s'),
     'user_agent' => $_SERVER['HTTP_USER_AGENT'] ?? 'unknown',
     'is_ios' => strpos($_SERVER['HTTP_USER_AGENT'] ?? '', 'iPhone') !== false || strpos($_SERVER['HTTP_USER_AGENT'] ?? '', 'iPad') !== false,
+    'session_id' => session_id(),
     'cookies' => $_COOKIE,
     'session_data' => [
         'customer_id' => $_SESSION['customer_id'] ?? null,
-        'customer_token' => isset($_SESSION['customer_token']) ? substr($_SESSION['customer_token'], 0, 10) . '...' : null,
-        'customer' => isset($_SESSION['customer']) ? 'set' : 'not set',
-        'session_id' => session_id()
+        'session_authenticated' => $_SESSION['session_authenticated'] ?? false,
+        'customer_login_time' => $_SESSION['customer_login_time'] ?? null,
+        'customer_last_activity' => $_SESSION['customer_last_activity'] ?? null,
+        'customer_data_exists' => isset($_SESSION['customer']),
+        'db_session_token' => isset($_SESSION['db_session_token']) ? 'set' : 'not set'
     ],
-    'current_customer' => get_current_customer() ? 'found' : 'not found'
+    'current_customer' => get_current_customer() ? 'found' : 'not found',
+    'session_status' => session_status() === PHP_SESSION_ACTIVE ? 'active' : 'inactive'
 ];
 
 echo json_encode($debug_info, JSON_PRETTY_PRINT);

--- a/login.php
+++ b/login.php
@@ -32,17 +32,15 @@ if($_SERVER['REQUEST_METHOD'] === 'POST'){
                 ]);
             }
         }else{
-            // Create session
+            // Create PHP session (no more custom cookies!)
             create_customer_session($cust['id']);
 
             // Update last login
             $upd = $pdo->prepare('UPDATE customers SET last_login = NOW() WHERE id = ?');
             $upd->execute([$cust['id']]);
 
-            // Set session variables
+            // Store customer data in session
             $_SESSION['customer'] = $cust;
-            $_SESSION['customer_login_time'] = time();
-            $_SESSION['customer_last_activity'] = time();
 
             // Log successful login
             $logger->logActivity($cust['id'], 'login', [
@@ -50,62 +48,16 @@ if($_SERVER['REQUEST_METHOD'] === 'POST'){
                 'login_success' => true,
                 'pin_attempts' => $_SESSION['pin_attempts'] ?? 1,
                 'user_agent' => $_SERVER['HTTP_USER_AGENT'] ?? 'unknown',
-                'is_ios' => strpos($_SERVER['HTTP_USER_AGENT'] ?? '', 'iPhone') !== false || strpos($_SERVER['HTTP_USER_AGENT'] ?? '', 'iPad') !== false
+                'session_id' => session_id()
             ]);
 
             unset($_SESSION['pin_attempts']);
 
-            // ENHANCED: iOS-specific redirect handling
-            $user_agent = $_SERVER['HTTP_USER_AGENT'] ?? '';
-            $is_ios = strpos($user_agent, 'iPhone') !== false || strpos($user_agent, 'iPad') !== false;
+            error_log("Successful login for customer " . $cust['id'] . " - session: " . session_id());
 
-            if ($is_ios) {
-                // iOS needs a bit more time for cookie processing
-                error_log("iOS login detected for customer " . $cust['id'] . " - using enhanced redirect");
-
-                // Set additional session data for iOS
-                $_SESSION['ios_login_success'] = true;
-                $_SESSION['login_timestamp'] = time();
-
-                // Use JavaScript redirect for better iOS compatibility
-                echo '<!DOCTYPE html>
-                <html>
-                <head>
-                    <meta charset="UTF-8">
-                    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-                    <title>Login erfolgreich</title>
-                </head>
-                <body>
-                    <script>
-                        console.log("iOS login redirect starting...");
-
-                        // Small delay to ensure cookie is set
-                        setTimeout(function() {
-                            console.log("Redirecting to dashboard...");
-                            window.location.href = "customer/index.php";
-                        }, 200);
-
-                        // Fallback after 3 seconds
-                        setTimeout(function() {
-                            if (window.location.href.indexOf("customer/index.php") === -1) {
-                                console.log("Fallback redirect triggered");
-                                window.location.replace("customer/index.php");
-                            }
-                        }, 3000);
-                    </script>
-                    <div style="text-align: center; padding: 50px; font-family: Arial;">
-                        <h2>✅ Login erfolgreich!</h2>
-                        <p>Du wirst weitergeleitet...</p>
-                        <p><a href="customer/index.php">Hier klicken falls die Weiterleitung nicht funktioniert</a></p>
-                    </div>
-                </body>
-                </html>';
-                exit;
-            } else {
-                // Standard redirect for non-iOS
-                header('Location: customer/index.php');
-                exit;
-            }
+            // Simple redirect - should work on all devices
+            header('Location: customer/index.php');
+            exit;
         }
     }
 }


### PR DESCRIPTION
## Summary
- Replace custom cookie-based customer session system with standard PHP sessions
- Update login, dashboard timeout/logout, and debug endpoint to use PHP sessions
- Simplify authentication flow and improve iOS compatibility

## Testing
- `php -l customer/auth.php`
- `php -l login.php`
- `php -l customer/index.php`
- `php -l customer/debug_session.php`


------
https://chatgpt.com/codex/tasks/task_e_68bc73f19c108323bdfc7d106658a83c