### PR TITLE
feat: add email delivery monitoring

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 
 # Sensitive config files
 config/credentials.php
+admin/logs/

--- a/admin/email_delivery_log.php
+++ b/admin/email_delivery_log.php
@@ -1,0 +1,66 @@
+<?php
+session_start();
+if (empty($_SESSION['admin'])) {
+    header('Location: login.php');
+    exit;
+}
+
+$log_file = __DIR__ . '/logs/email_delivery.log';
+$entries = [];
+
+if (file_exists($log_file)) {
+    $lines = file($log_file, FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES);
+    $lines = array_reverse($lines); // Neueste zuerst
+
+    foreach (array_slice($lines, 0, 100) as $line) { // Letzte 100 Einträge
+        $entry = json_decode($line, true);
+        if ($entry) {
+            $entries[] = $entry;
+        }
+    }
+}
+?>
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="UTF-8">
+    <title>Email Delivery Log</title>
+    <style>
+        body{font-family:Arial;margin:2em}
+        table{width:100%;border-collapse:collapse}
+        th,td{border:1px solid #ccc;padding:0.5em;text-align:left}
+        th{background:#4a90b8;color:#fff}
+        .success{color:#28a745;font-weight:bold}
+        .failed{color:#dc3545;font-weight:bold}
+    </style>
+</head>
+<body>
+    <h2 style="color:#4a90b8">📧 Email Delivery Log</h2>
+    <p><a href="dashboard.php">← Zurück zum Dashboard</a></p>
+
+    <table>
+        <tr>
+            <th>Timestamp</th>
+            <th>Email</th>
+            <th>Status</th>
+            <th>Details</th>
+            <th>IP</th>
+        </tr>
+        <?php foreach ($entries as $entry): ?>
+        <tr>
+            <td><?= htmlspecialchars($entry['timestamp']) ?></td>
+            <td><?= htmlspecialchars($entry['email']) ?></td>
+            <td class="<?= $entry['success'] ? 'success' : 'failed' ?>">
+                <?= $entry['success'] ? '✅ Erfolg' : '❌ Fehler' ?>
+            </td>
+            <td><?= htmlspecialchars($entry['details']) ?></td>
+            <td><?= htmlspecialchars($entry['ip']) ?></td>
+        </tr>
+        <?php endforeach; ?>
+    </table>
+
+    <?php if (empty($entries)): ?>
+        <p>Keine Email-Logs gefunden.</p>
+    <?php endif; ?>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add delivery logging and anti-spam headers for PIN mails
- show recent email delivery stats on admin dashboard
- provide email delivery log viewer and ignore log files

## Testing
- `php -l admin/send_pin.php`
- `php -l admin/dashboard.php`
- `php -l admin/email_delivery_log.php`


------
https://chatgpt.com/codex/tasks/task_e_68bc9ad67cd48323a06a6d496d3174b5