### PR TITLE
feat: add manual PWA update trigger

### DIFF
--- a/admin/dashboard.php
+++ b/admin/dashboard.php
@@ -290,8 +290,24 @@ $sw_path = __DIR__ . '/../sw.js';
             🗑️ Clear All Caches
         </button>
     </div>
+
+    <div style='margin-top:1rem;'>
+        <button onclick='testManualUpdate()' style='background:#52b3a4;color:white;padding:0.5rem 1rem;text-decoration:none;border:none;border-radius:4px;cursor:pointer;'>
+            🔧 Test Manual Update
+        </button>
+    </div>
 </div>
 
+<script>
+function testManualUpdate() {
+    const newWindow = window.open('/einfachlernen/customer/', '_blank');
+    setTimeout(() => {
+        if (newWindow) {
+            newWindow.postMessage({ type: 'TEST_MANUAL_UPDATE' }, '*');
+        }
+    }, 2000);
+}
+</script>
 
 <div style='background:#f8f9fa;padding:1.5rem;margin:2rem 0;border:1px solid #dee2e6;border-radius:8px;'>
     <h3 style='color:#4a90b8;margin-top:0;'>📧 Email Delivery Monitor</h3>

--- a/customer/index.php
+++ b/customer/index.php
@@ -587,6 +587,26 @@ if(!empty($_SESSION['customer'])) {
             font-size: 0.75rem;
         }
 
+        #app-version {
+            font-size: 0.7rem;
+            opacity: 0.8;
+            cursor: pointer;
+            padding: 0.2rem 0.5rem;
+            border-radius: 4px;
+            transition: all 0.3s ease;
+            user-select: none;
+        }
+
+        #app-version:hover {
+            background: rgba(74, 144, 184, 0.1);
+            opacity: 1;
+            transform: scale(1.05);
+        }
+
+        #app-version:active {
+            transform: scale(0.95);
+        }
+
         #appVersion {
             font-weight: 500;
             color: var(--primary);
@@ -874,8 +894,12 @@ if(!empty($_SESSION['customer'])) {
 
         <footer class="app-footer">
             <p>&copy; <?= date('Y') ?> Anna Braun Lerncoaching - Dein Partner für ganzheitliche Lernunterstützung</p>
-            <p class="app-version">
-                <small>App Version: <span id="appVersion">Lädt...</span></small>
+            <p style="margin-top: 0.5rem;">
+                <span id="app-version"
+                    onclick="checkForUpdatesManually()"
+                    title="Klicken um nach Updates zu suchen">
+                    App Version: <span id="appVersion">Lädt...</span>
+                </span>
             </p>
         </footer>
     </div>
@@ -1190,6 +1214,33 @@ if(!empty($_SESSION['customer'])) {
     }
 
     document.addEventListener('DOMContentLoaded', loadAppVersion);
+    </script>
+
+    <script>
+    document.addEventListener('DOMContentLoaded', () => {
+        const versionElement = document.getElementById('app-version');
+        if (versionElement) {
+            versionElement.addEventListener('mousedown', () => {
+                versionElement.style.background = 'rgba(74, 144, 184, 0.2)';
+            });
+
+            versionElement.addEventListener('mouseup', () => {
+                setTimeout(() => {
+                    versionElement.style.background = '';
+                }, 150);
+            });
+
+            versionElement.addEventListener('touchstart', () => {
+                versionElement.style.background = 'rgba(74, 144, 184, 0.2)';
+            });
+
+            versionElement.addEventListener('touchend', () => {
+                setTimeout(() => {
+                    versionElement.style.background = '';
+                }, 150);
+            });
+        }
+    });
     </script>
     <!-- PWA Install Button - ADD THIS SCRIPT BLOCK ONLY -->
     <script>

--- a/pwa-update.js
+++ b/pwa-update.js
@@ -1,6 +1,7 @@
 // PWA Update Fix für macOS - pwa-update.js ERSETZT VERSION
 let updateAvailable = false;
 let registration = null;
+let manualUpdateInProgress = false;
 const SW_PATH = window.location.pathname.includes('/einfachlernen/') ? '/einfachlernen/sw.js' : '/sw.js';
 
 // Register service worker with update detection
@@ -26,7 +27,13 @@ if ('serviceWorker' in navigator) {
                     if (newWorker.state === 'installed' && navigator.serviceWorker.controller) {
                         console.log('🎯 Update ready, showing notification');
                         updateAvailable = true;
-                        showUpdateNotification();
+
+                        if (manualUpdateInProgress) {
+                            showUpdateModal();
+                            manualUpdateInProgress = false;
+                        } else {
+                            showUpdateNotification();
+                        }
                     }
                 });
             });
@@ -35,11 +42,20 @@ if ('serviceWorker' in navigator) {
             if (reg.waiting) {
                 console.log('🎯 SW already waiting, showing update');
                 updateAvailable = true;
-                showUpdateNotification();
+                if (manualUpdateInProgress) {
+                    showUpdateModal();
+                    manualUpdateInProgress = false;
+                } else {
+                    showUpdateNotification();
+                }
             }
         })
         .catch(err => {
             console.error('❌ SW registration failed:', err);
+            if (manualUpdateInProgress) {
+                showNoUpdateModal();
+                manualUpdateInProgress = false;
+            }
         });
 
     // Listen for messages from service worker
@@ -205,6 +221,270 @@ function showUpdateSuccessMessage(version) {
     }, 5000);
 }
 
+// MANUAL UPDATE CHECK FUNCTION
+async function checkForUpdatesManually() {
+    console.log('🔍 Manual update check triggered');
+
+    if (!registration) {
+        console.warn('⚠️ No SW registration found');
+        showNoUpdateModal();
+        return;
+    }
+
+    manualUpdateInProgress = true;
+    showCheckingModal();
+
+    try {
+        await registration.update();
+
+        // Wait briefly to see if update is found
+        setTimeout(() => {
+            if (manualUpdateInProgress) {
+                console.log('✅ No update available');
+                showNoUpdateModal();
+                manualUpdateInProgress = false;
+            }
+        }, 3000);
+
+    } catch (error) {
+        console.error('❌ Manual update check failed:', error);
+        showNoUpdateModal();
+        manualUpdateInProgress = false;
+    }
+}
+
+function showUpdateModal() {
+    console.log('🎯 Showing update modal');
+
+    removeExistingModals();
+
+    const modal = document.createElement('div');
+    modal.id = 'update-modal';
+    modal.innerHTML = `
+        <div style="
+            position: fixed;
+            top: 0;
+            left: 0;
+            right: 0;
+            bottom: 0;
+            background: rgba(0,0,0,0.7);
+            z-index: 10000;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            padding: 1rem;
+        ">
+            <div style="
+                background: white;
+                border-radius: 12px;
+                padding: 2rem;
+                max-width: 400px;
+                width: 100%;
+                text-align: center;
+                box-shadow: 0 10px 30px rgba(0,0,0,0.3);
+            ">
+                <div style="
+                    font-size: 3rem;
+                    margin-bottom: 1rem;
+                ">🚀</div>
+                <h3 style="
+                    margin: 0 0 1rem 0;
+                    color: #4a90b8;
+                    font-size: 1.3rem;
+                ">App-Update verfügbar!</h3>
+                <p style="
+                    margin: 0 0 2rem 0;
+                    color: #666;
+                    line-height: 1.5;
+                ">Eine neue Version der App ist verfügbar. Möchten Sie jetzt aktualisieren?</p>
+                <div style="
+                    display: flex;
+                    gap: 1rem;
+                    justify-content: center;
+                ">
+                    <button id="update-modal-apply" style="
+                        background: #4a90b8;
+                        color: white;
+                        border: none;
+                        padding: 0.75rem 1.5rem;
+                        border-radius: 8px;
+                        cursor: pointer;
+                        font-weight: 600;
+                        flex: 1;
+                    ">Jetzt aktualisieren</button>
+                    <button id="update-modal-dismiss" style="
+                        background: #e0e0e0;
+                        color: #666;
+                        border: none;
+                        padding: 0.75rem 1.5rem;
+                        border-radius: 8px;
+                        cursor: pointer;
+                        flex: 1;
+                    ">Später</button>
+                </div>
+            </div>
+        </div>
+    `;
+
+    document.body.appendChild(modal);
+
+    document.getElementById('update-modal-apply').addEventListener('click', () => {
+        applyUpdate();
+        modal.remove();
+    });
+
+    document.getElementById('update-modal-dismiss').addEventListener('click', () => {
+        modal.remove();
+    });
+
+    modal.addEventListener('click', (e) => {
+        if (e.target === modal) {
+            modal.remove();
+        }
+    });
+}
+
+function showNoUpdateModal() {
+    console.log('✅ Showing no-update modal');
+
+    removeExistingModals();
+
+    const modal = document.createElement('div');
+    modal.id = 'no-update-modal';
+    modal.innerHTML = `
+        <div style="
+            position: fixed;
+            top: 0;
+            left: 0;
+            right: 0;
+            bottom: 0;
+            background: rgba(0,0,0,0.7);
+            z-index: 10000;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            padding: 1rem;
+        ">
+            <div style="
+                background: white;
+                border-radius: 12px;
+                padding: 2rem;
+                max-width: 400px;
+                width: 100%;
+                text-align: center;
+                box-shadow: 0 10px 30px rgba(0,0,0,0.3);
+            ">
+                <div style="
+                    font-size: 3rem;
+                    margin-bottom: 1rem;
+                ">✅</div>
+                <h3 style="
+                    margin: 0 0 1rem 0;
+                    color: #28a745;
+                    font-size: 1.3rem;
+                ">App ist aktuell!</h3>
+                <p style="
+                    margin: 0 0 2rem 0;
+                    color: #666;
+                    line-height: 1.5;
+                ">Sie verwenden bereits die neueste Version der App.</p>
+                <button id="no-update-modal-close" style="
+                    background: #28a745;
+                    color: white;
+                    border: none;
+                    padding: 0.75rem 2rem;
+                    border-radius: 8px;
+                    cursor: pointer;
+                    font-weight: 600;
+                ">OK</button>
+            </div>
+        </div>
+    `;
+
+    document.body.appendChild(modal);
+
+    document.getElementById('no-update-modal-close').addEventListener('click', () => {
+        modal.remove();
+    });
+
+    // Auto-close after 3 seconds
+    setTimeout(() => {
+        if (document.getElementById('no-update-modal')) {
+            modal.remove();
+        }
+    }, 3000);
+}
+
+function showCheckingModal() {
+    console.log('🔄 Showing checking modal');
+
+    removeExistingModals();
+
+    const modal = document.createElement('div');
+    modal.id = 'checking-modal';
+    modal.innerHTML = `
+        <div style="
+            position: fixed;
+            top: 0;
+            left: 0;
+            right: 0;
+            bottom: 0;
+            background: rgba(0,0,0,0.7);
+            z-index: 10000;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            padding: 1rem;
+        ">
+            <div style="
+                background: white;
+                border-radius: 12px;
+                padding: 2rem;
+                max-width: 400px;
+                width: 100%;
+                text-align: center;
+                box-shadow: 0 10px 30px rgba(0,0,0,0.3);
+            ">
+                <div style="
+                    width: 40px;
+                    height: 40px;
+                    border: 3px solid #f0f0f0;
+                    border-top: 3px solid #4a90b8;
+                    border-radius: 50%;
+                    animation: spin 1s linear infinite;
+                    margin: 0 auto 1rem auto;
+                "></div>
+                <h3 style="
+                    margin: 0 0 1rem 0;
+                    color: #4a90b8;
+                    font-size: 1.3rem;
+                ">Suche nach Updates...</h3>
+                <p style="
+                    margin: 0;
+                    color: #666;
+                ">Einen Moment bitte</p>
+            </div>
+        </div>
+        <style>
+            @keyframes spin {
+                0% { transform: rotate(0deg); }
+                100% { transform: rotate(360deg); }
+            }
+        </style>
+    `;
+
+    document.body.appendChild(modal);
+}
+
+function removeExistingModals() {
+    ['update-modal', 'no-update-modal', 'checking-modal', 'update-notification'].forEach(id => {
+        const existing = document.getElementById(id);
+        if (existing) {
+            existing.remove();
+        }
+    });
+}
+
 // Enhanced admin functions with logging
 function forceClientUpdates() {
     console.log('🚨 Force update triggered from admin');
@@ -259,26 +539,38 @@ window.addEventListener('load', () => {
     }
 });
 
-// Debug helper: Manual update check
-function manualUpdateCheck() {
-    console.log('🔄 Manual update check triggered');
-    if (registration) {
-        registration.update().then(() => {
-            console.log('✅ Manual update check completed');
-        }).catch(err => {
-            console.error('❌ Manual update check failed:', err);
-        });
-    } else {
-        console.warn('⚠️ No registration found for manual check');
+// Listen for manual update test messages
+window.addEventListener('message', event => {
+    if (event.data && event.data.type === 'TEST_MANUAL_UPDATE') {
+        checkForUpdatesManually();
     }
-}
+});
 
-// Expose debug functions globally
+// Expose functions globally
 window.debugPWA = {
-    manualUpdateCheck,
+    checkForUpdatesManually,
     forceClientUpdates,
     clearAllCaches,
     showUpdateNotification
 };
+
+window.checkForUpdatesManually = checkForUpdatesManually;
+
+window.addEventListener('error', (e) => {
+    if (e.message && e.message.includes('checkForUpdatesManually')) {
+        console.error('Manual update check failed:', e);
+        if (confirm('Update-Check fehlgeschlagen. Cache leeren und neu laden?')) {
+            if ('caches' in window) {
+                caches.keys().then(cacheNames => {
+                    return Promise.all(cacheNames.map(cacheName => caches.delete(cacheName)));
+                }).then(() => {
+                    window.location.reload(true);
+                });
+            } else {
+                window.location.reload(true);
+            }
+        }
+    }
+});
 
 console.log('🔧 PWA Debug functions available via window.debugPWA');


### PR DESCRIPTION
## Summary
- add manual PWA update check with update/no-update modals and error handling
- make footer version clickable to trigger update check and add touch feedback
- include admin dashboard button to test manual update flow

## Testing
- `php -l customer/index.php`
- `php -l admin/dashboard.php`
- `node --check pwa-update.js`


------
https://chatgpt.com/codex/tasks/task_e_68bc9c4f9f84832395fda82db95a6de0