### PR TITLE
Add secure customer deletion to admin dashboard

### DIFF
--- a/admin/dashboard.php
+++ b/admin/dashboard.php
@@ -201,7 +201,7 @@ $email_stats = getEmailDeliveryStats(7);
 <?php endif; ?>
 <p>Total customers: <?=$total?></p>
 <table>
-    <tr><th>Email</th><th>Name</th><th>Phone</th><th>Status</th><th>Created</th><th>PIN Status</th><th>Action</th><th>Activity</th></tr>
+    <tr><th>Email</th><th>Name</th><th>Phone</th><th>Status</th><th>Created</th><th>PIN Status</th><th>Action</th><th>Activity</th><th>Delete</th></tr>
     <?php foreach($customers as $c): ?>
     <tr>
         <td><?=htmlspecialchars($c['email'])?></td>
@@ -217,6 +217,16 @@ $email_stats = getEmailDeliveryStats(7);
             </form>
         </td>
         <td><a href='?view_activity=<?=$c['id']?>'>View Activity</a></td>
+        <td>
+            <form method="post" action="delete_customer.php" style="margin:0;display:inline;">
+                <input type="hidden" name="customer_id" value="<?=$c['id']?>">
+                <button type="submit" 
+                        style="background:#dc3545;color:white;border:none;padding:0.3em 0.6em;font-size:0.8em;border-radius:3px;cursor:pointer;"
+                        onclick="return confirmDelete('<?=htmlspecialchars($c['email'])?>')">
+                    🗑️ Delete
+                </button>
+            </form>
+        </td>
     </tr>
     <?php endforeach; ?>
 </table>
@@ -793,6 +803,21 @@ setInterval(() => {
     } // End customer found check
 } // End activity view section
 ?>
+<script>
+function confirmDelete(email) {
+    return confirm(
+        `🚨 CUSTOMER DELETION WARNING 🚨\n\n` +
+        `You are about to permanently delete:\n` +
+        `Email: ${email}\n\n` +
+        `This action will:\n` +
+        `✗ Delete the customer account\n` +
+        `✗ Delete all session data\n` +
+        `✗ Delete all activity history\n` +
+        `✗ Cannot be undone\n\n` +
+        `Are you absolutely sure?`
+    );
+}
+</script>
 <script src="../pwa-update.js"></script>
 </body>
 </html>

--- a/admin/delete_customer.php
+++ b/admin/delete_customer.php
@@ -1,0 +1,81 @@
+<?php
+session_start();
+if(empty($_SESSION['admin'])){header('Location: login.php');exit;}
+if(isset($_SESSION['LAST_ACTIVITY']) && time() - $_SESSION['LAST_ACTIVITY'] > 1800){session_unset();session_destroy();header('Location: login.php');exit;}
+$_SESSION['LAST_ACTIVITY'] = time();
+
+function getPDO() {
+    $config = require __DIR__ . '/config.php';
+    try {
+        return new PDO(
+            "mysql:host={$config['DB_HOST']};dbname={$config['DB_NAME']};charset=utf8mb4",
+            $config['DB_USER'],
+            $config['DB_PASS'],
+            [PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION]
+        );
+    } catch (PDOException $e) {
+        die('DB connection failed: ' . htmlspecialchars($e->getMessage()));
+    }
+}
+
+function respond(bool $success, string $message): void {
+    $param = $success ? 'success' : 'error';
+    header('Location: dashboard.php?' . $param . '=' . urlencode($message));
+    exit;
+}
+
+if ($_SERVER['REQUEST_METHOD'] !== 'POST' || empty($_POST['customer_id'])) {
+    respond(false, 'Invalid delete request');
+}
+
+$customer_id = (int)$_POST['customer_id'];
+if ($customer_id <= 0) {
+    respond(false, 'Invalid customer ID');
+}
+
+$pdo = getPDO();
+
+try {
+    // Get customer data before deletion for logging
+    $stmt = $pdo->prepare('SELECT email, first_name, last_name FROM customers WHERE id = ?');
+    $stmt->execute([$customer_id]);
+    $customer = $stmt->fetch(PDO::FETCH_ASSOC);
+    
+    if (!$customer) {
+        respond(false, 'Customer not found');
+    }
+    
+    // Log deletion activity (before actual deletion)
+    require_once 'ActivityLogger.php';
+    $logger = new ActivityLogger($pdo);
+    $logger->logActivity($customer_id, 'customer_deleted', [
+        'deleted_by_admin' => $_SESSION['admin'],
+        'customer_email' => $customer['email'],
+        'customer_name' => trim($customer['first_name'] . ' ' . $customer['last_name']),
+        'deletion_timestamp' => date('Y-m-d H:i:s')
+    ]);
+    
+    // Start transaction for safe deletion
+    $pdo->beginTransaction();
+    
+    // Delete customer (CASCADE will handle sessions + activities)
+    $delete_stmt = $pdo->prepare('DELETE FROM customers WHERE id = ?');
+    $result = $delete_stmt->execute([$customer_id]);
+    
+    if (!$result || $delete_stmt->rowCount() === 0) {
+        $pdo->rollBack();
+        respond(false, 'Failed to delete customer');
+    }
+    
+    $pdo->commit();
+    
+    respond(true, "Customer '{$customer['email']}' successfully deleted");
+    
+} catch (Exception $e) {
+    if ($pdo->inTransaction()) {
+        $pdo->rollBack();
+    }
+    error_log("Customer deletion error: " . $e->getMessage());
+    respond(false, 'Deletion failed - system error');
+}
+?>


### PR DESCRIPTION
## Summary
- Add `delete_customer.php` for transactional customer removal with activity logging
- Extend dashboard table with delete column and confirmation prompt
- Add JavaScript confirmation dialog for irreversible deletions

## Testing
- `php -l admin/delete_customer.php`
- `php -l admin/dashboard.php`


------
https://chatgpt.com/codex/tasks/task_e_68bca9549fd08323b73e800153af3313