### PR TITLE
Add beta messaging system for test customer

### DIFF
--- a/admin/beta_messaging.php
+++ b/admin/beta_messaging.php
@@ -1,0 +1,139 @@
+<?php
+// admin/beta_messaging.php - ADMIN MESSAGING INTERFACE
+session_start();
+if (empty($_SESSION['admin'])) {
+    header('Location: login.php');
+    exit;
+}
+
+function getPDO()
+{
+    $config = require __DIR__ . '/config.php';
+    return new PDO(
+        "mysql:host={$config['DB_HOST']};dbname={$config['DB_NAME']};charset=utf8mb4",
+        $config['DB_USER'],
+        $config['DB_PASS'],
+        [PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION]
+    );
+}
+
+$pdo = getPDO();
+
+// Create table if not exists (beta feature safeguard)
+$pdo->exec("CREATE TABLE IF NOT EXISTS beta_messages (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    from_admin BOOLEAN DEFAULT TRUE,
+    to_customer_email VARCHAR(100) NOT NULL,
+    message_text TEXT NOT NULL,
+    message_type ENUM('info', 'success', 'warning', 'question') DEFAULT 'info',
+    is_read BOOLEAN DEFAULT FALSE,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    INDEX idx_customer_email (to_customer_email),
+    INDEX idx_unread (is_read, to_customer_email),
+    INDEX idx_created (created_at)
+)");
+
+$success = '';
+
+// Send message
+if (($_POST['action'] ?? '') === 'send' && isset($_POST['message'])) {
+    $message = trim($_POST['message']);
+    $allowed_types = ['info', 'success', 'warning', 'question'];
+    $message_type = in_array($_POST['type'] ?? 'info', $allowed_types, true) ? $_POST['type'] : 'info';
+
+    if ($message !== '') {
+        $stmt = $pdo->prepare('INSERT INTO beta_messages (to_customer_email, message_text, message_type) VALUES (?, ?, ?)');
+        $stmt->execute([
+            'marcus@einfachstarten.jetzt',
+            $message,
+            $message_type
+        ]);
+        $success = '✅ Beta-Nachricht an marcus@einfachstarten.jetzt gesendet!';
+    }
+}
+
+// Get message history
+$messages = $pdo->prepare('SELECT * FROM beta_messages WHERE to_customer_email = ? ORDER BY created_at DESC LIMIT 20');
+$messages->execute(['marcus@einfachstarten.jetzt']);
+$message_history = $messages->fetchAll(PDO::FETCH_ASSOC);
+?>
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="UTF-8">
+    <title>🧪 Beta Messaging</title>
+    <style>
+        body{font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;margin:2rem;background:#f8fafc;color:#1f2937}
+        .container{max-width:800px;margin:0 auto}
+        .send-form{background:white;padding:2rem;border-radius:12px;margin-bottom:2rem;box-shadow:0 2px 8px rgba(0,0,0,0.1)}
+        .history{background:white;padding:2rem;border-radius:12px;box-shadow:0 2px 8px rgba(0,0,0,0.1)}
+        .message{border-left:4px solid #4a90b8;padding:1rem;margin:1rem 0;background:#f8f9fa;border-radius:0 8px 8px 0}
+        .message.read{opacity:0.7}
+        .success{background:#d4edda;color:#155724;padding:1rem;border-radius:5px;margin:1rem 0}
+        select,textarea,button{padding:0.75rem;margin:0.5rem 0;border-radius:6px;border:1px solid #d1d5db;font-family:inherit}
+        button{background:#4a90b8;color:white;border:none;cursor:pointer;font-weight:500;transition:all 0.2s}
+        button:hover{background:#2563eb;transform:translateY(-1px)}
+        textarea{width:100%;min-height:120px;resize:vertical}
+        .beta-badge{background:linear-gradient(135deg,#667eea,#764ba2);color:white;padding:0.5rem 1rem;border-radius:20px;font-size:0.875rem;font-weight:bold}
+        .back-link{color:#2563eb;text-decoration:none}
+        .back-link:hover{text-decoration:underline}
+    </style>
+</head>
+<body>
+<div class="container">
+    <h1>🧪 Beta Messaging System</h1>
+    <p><a class="back-link" href="dashboard.php">← Zurück zum Dashboard</a></p>
+    <p><span class="beta-badge">BETA FEATURE</span> Nur für marcus@einfachstarten.jetzt</p>
+
+    <?php if ($success): ?>
+        <div class="success"><?=$success?></div>
+    <?php endif; ?>
+
+    <div class="send-form">
+        <h3>📤 Nachricht an Beta-User senden</h3>
+        <form method="post">
+            <input type="hidden" name="action" value="send">
+
+            <p><strong>Empfänger:</strong> marcus@einfachstarten.jetzt</p>
+
+            <select name="type" style="width:200px">
+                <option value="info">ℹ️ Information</option>
+                <option value="success">✅ Erfolg/Bestätigung</option>
+                <option value="warning">⚠️ Warnung/Hinweis</option>
+                <option value="question">❓ Frage/Feedback</option>
+            </select>
+
+            <textarea name="message" placeholder="Nachricht eingeben..." required></textarea>
+
+            <button type="submit">📨 Beta-Nachricht senden</button>
+        </form>
+    </div>
+
+    <div class="history">
+        <h3>📋 Nachrichten-Verlauf (<?=count($message_history)?>)</h3>
+        <?php if (empty($message_history)): ?>
+            <p style="color:#6b7280;font-style:italic">Noch keine Nachrichten gesendet.</p>
+        <?php else: ?>
+            <?php foreach ($message_history as $msg): ?>
+            <div class="message <?=$msg['is_read'] ? 'read' : ''?>">
+                <div style="display:flex;justify-content:space-between;align-items:center;margin-bottom:0.5rem">
+                    <span style="font-size:0.875rem;color:#6b7280">
+                        <?=date('d.m.Y H:i', strtotime($msg['created_at']))?> •
+                        <?php
+                        $icons = ['info' => 'ℹ️', 'success' => '✅', 'warning' => '⚠️', 'question' => '❓'];
+                        echo $icons[$msg['message_type']] ?? 'ℹ️';
+                        ?>
+                        <?=ucfirst($msg['message_type'])?>
+                    </span>
+                    <span style="font-size:0.75rem;color:<?=$msg['is_read'] ? '#28a745' : '#dc3545'?>">
+                        <?=$msg['is_read'] ? '✓ Gelesen' : '● Ungelesen'?>
+                    </span>
+                </div>
+                <div><?=nl2br(htmlspecialchars($msg['message_text']))?></div>
+            </div>
+            <?php endforeach; ?>
+        <?php endif; ?>
+    </div>
+</div>
+</body>
+</html>

--- a/admin/dashboard.php
+++ b/admin/dashboard.php
@@ -388,6 +388,7 @@ $email_stats = getEmailDeliveryStats(7);
     <a href="test_mail.php">E-Mail testen</a>
     <a href="analytics.php">Kunden-Analytics</a>
     <a href="migrate.php">Datenbank-Migration</a>
+    <a href="beta_messaging.php">🧪 Beta Messaging</a>
     <a href="?logout=1">Abmelden</a>
 </nav>
 <?php if(!empty($_GET['success'])): ?>

--- a/admin/migrate.php
+++ b/admin/migrate.php
@@ -101,6 +101,26 @@ try {
         echo "<p style='color:red'>❌ customer_activities creation failed: " . htmlspecialchars($e->getMessage()) . "</p>";
     }
 
+    // Create beta messaging table (beta features)
+    echo "<h3>Creating beta_messages table (beta features):</h3>";
+    try {
+        $pdo->exec("CREATE TABLE IF NOT EXISTS beta_messages (
+            id INT AUTO_INCREMENT PRIMARY KEY,
+            from_admin BOOLEAN DEFAULT TRUE,
+            to_customer_email VARCHAR(100) NOT NULL,
+            message_text TEXT NOT NULL,
+            message_type ENUM('info', 'success', 'warning', 'question') DEFAULT 'info',
+            is_read BOOLEAN DEFAULT FALSE,
+            created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+            INDEX idx_customer_email (to_customer_email),
+            INDEX idx_unread (is_read, to_customer_email),
+            INDEX idx_created (created_at)
+        )");
+        echo "<p style='color:green'>✅ beta_messages table ready</p>";
+    } catch (PDOException $e) {
+        echo "<p style='color:red'>❌ beta_messages creation failed: " . htmlspecialchars($e->getMessage()) . "</p>";
+    }
+
     // Create analytics views
     echo "<h3>Creating analytics views:</h3>";
     try {

--- a/beta/index.php
+++ b/beta/index.php
@@ -1,0 +1,135 @@
+<?php
+// beta/index.php - BETA CUSTOMER APP
+session_start();
+
+// BETA ACCESS GATE - Nur für Testuser
+function checkBetaAccess() {
+    require_once __DIR__ . '/../customer/auth.php';
+    $customer = get_current_customer();
+
+    if (!$customer || $customer['email'] !== 'marcus@einfachstarten.jetzt') {
+        echo '<!DOCTYPE html>
+        <html><head><meta charset="UTF-8"><title>Beta Access</title></head>
+        <body style="font-family:Arial;text-align:center;padding:3rem;background:#f8fafc">
+            <h1>🧪 Beta Access</h1>
+            <p>Diese Beta-App ist nur für autorisierte Testuser zugänglich.</p>
+            <p><a href="../login.php">← Zum normalen Login</a></p>
+        </body></html>';
+        exit;
+    }
+    return $customer;
+}
+
+$customer = checkBetaAccess();
+
+function getPDO() {
+    $config = require __DIR__ . '/../admin/config.php';
+    return new PDO(
+        "mysql:host={$config['DB_HOST']};dbname={$config['DB_NAME']};charset=utf8mb4",
+        $config['DB_USER'],
+        $config['DB_PASS'],
+        [PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION]
+    );
+}
+
+// Get unread messages
+function getUnreadMessages($email) {
+    $pdo = getPDO();
+    $stmt = $pdo->prepare('SELECT * FROM beta_messages WHERE to_customer_email = ? AND is_read = 0 ORDER BY created_at DESC');
+    $stmt->execute([$email]);
+    return $stmt->fetchAll(PDO::FETCH_ASSOC);
+}
+
+// Mark message as read
+if (!empty($_POST['mark_read'])) {
+    $messageId = isset($_POST['message_id']) ? (int)$_POST['message_id'] : 0;
+    if ($messageId <= 0) {
+        header('Location: index.php');
+        exit;
+    }
+    $pdo = getPDO();
+    $stmt = $pdo->prepare('UPDATE beta_messages SET is_read = 1 WHERE id = ? AND to_customer_email = ?');
+    $stmt->execute([$messageId, $customer['email']]);
+    header('Location: index.php');
+    exit;
+}
+
+$messages = getUnreadMessages($customer['email']);
+?>
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>🧪 Beta Customer Dashboard</title>
+    <style>
+        body{font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;margin:0;background:#f8fafc}
+        .beta-banner{background:linear-gradient(135deg,#667eea,#764ba2);color:white;padding:0.75rem;text-align:center;font-weight:bold}
+        .container{max-width:800px;margin:2rem auto;padding:0 1rem}
+        .welcome{background:white;padding:2rem;border-radius:12px;margin-bottom:2rem;box-shadow:0 2px 8px rgba(0,0,0,0.1)}
+        .messages-section{background:white;padding:2rem;border-radius:12px;margin-bottom:2rem;box-shadow:0 2px 8px rgba(0,0,0,0.1)}
+        .message{border-left:4px solid #4a90b8;padding:1rem;margin:1rem 0;background:#f8f9fa;border-radius:0 8px 8px 0}
+        .message.success{border-left-color:#28a745}
+        .message.warning{border-left-color:#ffc107}
+        .message.question{border-left-color:#6f42c1}
+        .message-meta{font-size:0.875rem;color:#6b7280;margin-bottom:0.5rem}
+        .message-text{color:#1f2937;line-height:1.6}
+        .mark-read-btn{background:#28a745;color:white;border:none;padding:0.25rem 0.75rem;border-radius:4px;cursor:pointer;font-size:0.75rem;margin-top:0.5rem}
+        .nav-links{text-align:center;margin:2rem 0}
+        .nav-links a{color:#4a90b8;text-decoration:none;margin:0 1rem;padding:0.5rem 1rem;border:1px solid #4a90b8;border-radius:6px;transition:all 0.2s}
+        .nav-links a:hover{background:#4a90b8;color:white}
+    </style>
+</head>
+<body>
+    <div class="beta-banner">
+        🧪 BETA VERSION - Test Features für marcus@einfachstarten.jetzt
+    </div>
+
+    <div class="container">
+        <div class="welcome">
+            <h1>Willkommen, <?=htmlspecialchars($customer['first_name'])?>! 👋</h1>
+            <p>Du nutzt die Beta-Version mit neuen experimentellen Features.</p>
+        </div>
+
+        <?php if (!empty($messages)): ?>
+        <div class="messages-section">
+            <h2>📨 Neue Nachrichten (<?=count($messages)?>)</h2>
+            <?php foreach ($messages as $msg): ?>
+            <div class="message <?=htmlspecialchars($msg['message_type'])?>">
+                <div class="message-meta">
+                    📅 <?=date('d.m.Y H:i', strtotime($msg['created_at']))?> •
+                    <?php
+                    $icons = ['info' => 'ℹ️', 'success' => '✅', 'warning' => '⚠️', 'question' => '❓'];
+                    echo $icons[$msg['message_type']] ?? 'ℹ️';
+                    ?>
+                    <?=ucfirst($msg['message_type'])?>
+                </div>
+                <div class="message-text"><?=nl2br(htmlspecialchars($msg['message_text']))?></div>
+                <form method="post" style="margin:0;display:inline">
+                    <input type="hidden" name="message_id" value="<?=htmlspecialchars($msg['id'])?>">
+                    <input type="hidden" name="mark_read" value="1">
+                    <button type="submit" class="mark-read-btn">✓ Als gelesen markieren</button>
+                </form>
+            </div>
+            <?php endforeach; ?>
+        </div>
+        <?php else: ?>
+        <div class="messages-section" style="text-align:center;color:#6b7280">
+            <h2>📨 Keine neuen Nachrichten</h2>
+            <p>Alle Beta-Infos sind gelesen. Schau später nochmal vorbei!</p>
+        </div>
+        <?php endif; ?>
+
+        <div class="nav-links">
+            <a href="../customer/dashboard.php">📊 Dashboard</a>
+            <a href="../customer/booking.php">📅 Termine buchen</a>
+            <a href="../customer/appointments.php">📋 Meine Termine</a>
+            <a href="../login.php?logout=1">🚪 Abmelden</a>
+        </div>
+
+        <div style="text-align:center;margin:2rem 0;color:#6b7280;font-size:0.875rem">
+            <p>🧪 Beta Features werden kontinuierlich erweitert</p>
+        </div>
+    </div>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add beta customer dashboard gated to marcus@einfachstarten.jetzt with messaging UI
- create admin messaging interface and navigation entry for beta communication
- extend migration to provision isolated beta_messages table

## Testing
- php -l beta/index.php
- php -l admin/beta_messaging.php

------
https://chatgpt.com/codex/tasks/task_e_68ca472dfbd883238bdb1b9ebcaa3c69