### PR TITLE
Fix beta app session validation and admin messaging

### DIFF
--- a/admin/beta_messaging.php
+++ b/admin/beta_messaging.php
@@ -1,13 +1,9 @@
 <?php
-// admin/beta_messaging.php - ADMIN MESSAGING INTERFACE
+// admin/beta_messaging.php - Korrigierter Admin Bereich
 session_start();
-if (empty($_SESSION['admin'])) {
-    header('Location: login.php');
-    exit;
-}
+if(empty($_SESSION['admin'])){header('Location: login.php');exit;}
 
-function getPDO()
-{
+function getPDO() {
     $config = require __DIR__ . '/config.php';
     return new PDO(
         "mysql:host={$config['DB_HOST']};dbname={$config['DB_NAME']};charset=utf8mb4",
@@ -19,7 +15,7 @@ function getPDO()
 
 $pdo = getPDO();
 
-// Create table if not exists (beta feature safeguard)
+// Create table automatically
 $pdo->exec("CREATE TABLE IF NOT EXISTS beta_messages (
     id INT AUTO_INCREMENT PRIMARY KEY,
     from_admin BOOLEAN DEFAULT TRUE,
@@ -28,6 +24,7 @@ $pdo->exec("CREATE TABLE IF NOT EXISTS beta_messages (
     message_type ENUM('info', 'success', 'warning', 'question') DEFAULT 'info',
     is_read BOOLEAN DEFAULT FALSE,
     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    
     INDEX idx_customer_email (to_customer_email),
     INDEX idx_unread (is_read, to_customer_email),
     INDEX idx_created (created_at)
@@ -35,20 +32,31 @@ $pdo->exec("CREATE TABLE IF NOT EXISTS beta_messages (
 
 $success = '';
 
-// Send message
-if (($_POST['action'] ?? '') === 'send' && isset($_POST['message'])) {
-    $message = trim($_POST['message']);
-    $allowed_types = ['info', 'success', 'warning', 'question'];
-    $message_type = in_array($_POST['type'] ?? 'info', $allowed_types, true) ? $_POST['type'] : 'info';
+// Check if beta user exists
+$beta_user_check = $pdo->prepare('SELECT * FROM customers WHERE email = ?');
+$beta_user_check->execute(['marcus@einfachstarten.jetzt']);
+$beta_user = $beta_user_check->fetch(PDO::FETCH_ASSOC);
 
+if (!$beta_user) {
+    echo '<div style="background:#f8d7da;color:#721c24;padding:1rem;border-radius:5px;margin:2rem;text-align:center">
+        ❌ Beta-User marcus@einfachstarten.jetzt nicht in der Datenbank gefunden!<br>
+        Bitte erst den User anlegen bevor das Messaging getestet wird.
+    </div>';
+    exit;
+}
+
+// Send message
+if (($_POST['action'] ?? '') === 'send') {
+    $message = trim($_POST['message'] ?? '');
+    $type = $_POST['type'] ?? 'info';
+    $allowedTypes = ['info', 'success', 'warning', 'question'];
     if ($message !== '') {
+        if (!in_array($type, $allowedTypes, true)) {
+            $type = 'info';
+        }
         $stmt = $pdo->prepare('INSERT INTO beta_messages (to_customer_email, message_text, message_type) VALUES (?, ?, ?)');
-        $stmt->execute([
-            'marcus@einfachstarten.jetzt',
-            $message,
-            $message_type
-        ]);
-        $success = '✅ Beta-Nachricht an marcus@einfachstarten.jetzt gesendet!';
+        $stmt->execute(['marcus@einfachstarten.jetzt', $message, $type]);
+        $success = "✅ Beta-Nachricht erfolgreich gesendet!";
     }
 }
 
@@ -63,8 +71,9 @@ $message_history = $messages->fetchAll(PDO::FETCH_ASSOC);
     <meta charset="UTF-8">
     <title>🧪 Beta Messaging</title>
     <style>
-        body{font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;margin:2rem;background:#f8fafc;color:#1f2937}
-        .container{max-width:800px;margin:0 auto}
+        body{font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;margin:2rem;background:#f8fafc}
+        .container{max-width:900px;margin:0 auto}
+        .header{background:linear-gradient(135deg,#667eea,#764ba2);color:white;padding:2rem;border-radius:12px;margin-bottom:2rem;text-align:center}
         .send-form{background:white;padding:2rem;border-radius:12px;margin-bottom:2rem;box-shadow:0 2px 8px rgba(0,0,0,0.1)}
         .history{background:white;padding:2rem;border-radius:12px;box-shadow:0 2px 8px rgba(0,0,0,0.1)}
         .message{border-left:4px solid #4a90b8;padding:1rem;margin:1rem 0;background:#f8f9fa;border-radius:0 8px 8px 0}
@@ -75,58 +84,73 @@ $message_history = $messages->fetchAll(PDO::FETCH_ASSOC);
         button:hover{background:#2563eb;transform:translateY(-1px)}
         textarea{width:100%;min-height:120px;resize:vertical}
         .beta-badge{background:linear-gradient(135deg,#667eea,#764ba2);color:white;padding:0.5rem 1rem;border-radius:20px;font-size:0.875rem;font-weight:bold}
-        .back-link{color:#2563eb;text-decoration:none}
-        .back-link:hover{text-decoration:underline}
+        .user-info{background:#e3f2fd;padding:1rem;border-radius:8px;margin:1rem 0}
     </style>
 </head>
 <body>
 <div class="container">
-    <h1>🧪 Beta Messaging System</h1>
-    <p><a class="back-link" href="dashboard.php">← Zurück zum Dashboard</a></p>
-    <p><span class="beta-badge">BETA FEATURE</span> Nur für marcus@einfachstarten.jetzt</p>
-
-    <?php if ($success): ?>
+    <div class="header">
+        <h1>🧪 Beta Messaging System</h1>
+        <p>Direkter Kommunikationskanal mit Beta-Usern</p>
+    </div>
+    
+    <p><a href="dashboard.php">← Zurück zum Dashboard</a></p>
+    
+    <div class="user-info">
+        <strong>Beta-User Status:</strong><br>
+        Name: <?=htmlspecialchars($beta_user['first_name'] . ' ' . $beta_user['last_name'])?><br>
+        Email: <?=htmlspecialchars($beta_user['email'])?><br>
+        Status: <?=htmlspecialchars($beta_user['status'])?><br>
+        Registriert: <?=htmlspecialchars($beta_user['created_at'])?>
+    </div>
+    
+    <?php if(!empty($success)): ?>
         <div class="success"><?=$success?></div>
     <?php endif; ?>
-
+    
     <div class="send-form">
         <h3>📤 Nachricht an Beta-User senden</h3>
         <form method="post">
             <input type="hidden" name="action" value="send">
-
-            <p><strong>Empfänger:</strong> marcus@einfachstarten.jetzt</p>
-
-            <select name="type" style="width:200px">
-                <option value="info">ℹ️ Information</option>
+            
+            <p><strong>Empfänger:</strong> <?=htmlspecialchars($beta_user['first_name'])?> (marcus@einfachstarten.jetzt)</p>
+            
+            <select name="type" style="width:250px">
+                <option value="info">ℹ️ Information/Update</option>
                 <option value="success">✅ Erfolg/Bestätigung</option>
-                <option value="warning">⚠️ Warnung/Hinweis</option>
-                <option value="question">❓ Frage/Feedback</option>
+                <option value="warning">⚠️ Warnung/Wichtiger Hinweis</option>
+                <option value="question">❓ Frage/Feedback benötigt</option>
             </select>
+            
+            <textarea name="message" placeholder="Beta-Nachricht eingeben... 
 
-            <textarea name="message" placeholder="Nachricht eingeben..." required></textarea>
-
+Beispiele:
+- Neues Feature xyz ist verfügbar zum Testen
+- Bitte teste die neue Booking-Funktion und gib Feedback
+- Warnung: Beta-System wird morgen um 14:00 neu gestartet" required></textarea>
+            
             <button type="submit">📨 Beta-Nachricht senden</button>
         </form>
     </div>
-
+    
     <div class="history">
         <h3>📋 Nachrichten-Verlauf (<?=count($message_history)?>)</h3>
-        <?php if (empty($message_history)): ?>
-            <p style="color:#6b7280;font-style:italic">Noch keine Nachrichten gesendet.</p>
+        <?php if(empty($message_history)): ?>
+            <p style="color:#6b7280;font-style:italic">Noch keine Nachrichten gesendet. Schicke die erste Beta-Nachricht!</p>
         <?php else: ?>
-            <?php foreach ($message_history as $msg): ?>
+            <?php foreach($message_history as $msg): ?>
             <div class="message <?=$msg['is_read'] ? 'read' : ''?>">
                 <div style="display:flex;justify-content:space-between;align-items:center;margin-bottom:0.5rem">
                     <span style="font-size:0.875rem;color:#6b7280">
-                        <?=date('d.m.Y H:i', strtotime($msg['created_at']))?> •
+                        <?=date('d.m.Y H:i', strtotime($msg['created_at']))?> • 
                         <?php
                         $icons = ['info' => 'ℹ️', 'success' => '✅', 'warning' => '⚠️', 'question' => '❓'];
                         echo $icons[$msg['message_type']] ?? 'ℹ️';
                         ?>
                         <?=ucfirst($msg['message_type'])?>
                     </span>
-                    <span style="font-size:0.75rem;color:<?=$msg['is_read'] ? '#28a745' : '#dc3545'?>">
-                        <?=$msg['is_read'] ? '✓ Gelesen' : '● Ungelesen'?>
+                    <span style="font-size:0.75rem;color:<?=$msg['is_read'] ? '#28a745' : '#dc3545'?>;font-weight:bold">
+                        <?=$msg['is_read'] ? '✓ GELESEN' : '● UNGELESEN'?>
                     </span>
                 </div>
                 <div><?=nl2br(htmlspecialchars($msg['message_text']))?></div>

--- a/beta/index.php
+++ b/beta/index.php
@@ -1,60 +1,120 @@
 <?php
-// beta/index.php - BETA CUSTOMER APP
+// beta/index.php - CORRECTED BETA CUSTOMER APP
+ini_set('display_errors', 1);
+error_reporting(E_ALL);
+
 session_start();
 
-// BETA ACCESS GATE - Nur für Testuser
-function checkBetaAccess() {
-    require_once __DIR__ . '/../customer/auth.php';
-    $customer = get_current_customer();
-
-    if (!$customer || $customer['email'] !== 'marcus@einfachstarten.jetzt') {
-        echo '<!DOCTYPE html>
-        <html><head><meta charset="UTF-8"><title>Beta Access</title></head>
-        <body style="font-family:Arial;text-align:center;padding:3rem;background:#f8fafc">
-            <h1>🧪 Beta Access</h1>
-            <p>Diese Beta-App ist nur für autorisierte Testuser zugänglich.</p>
-            <p><a href="../login.php">← Zum normalen Login</a></p>
-        </body></html>';
-        exit;
-    }
-    return $customer;
-}
-
-$customer = checkBetaAccess();
-
+// Function to get PDO connection
 function getPDO() {
     $config = require __DIR__ . '/../admin/config.php';
-    return new PDO(
-        "mysql:host={$config['DB_HOST']};dbname={$config['DB_NAME']};charset=utf8mb4",
-        $config['DB_USER'],
-        $config['DB_PASS'],
-        [PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION]
-    );
-}
-
-// Get unread messages
-function getUnreadMessages($email) {
-    $pdo = getPDO();
-    $stmt = $pdo->prepare('SELECT * FROM beta_messages WHERE to_customer_email = ? AND is_read = 0 ORDER BY created_at DESC');
-    $stmt->execute([$email]);
-    return $stmt->fetchAll(PDO::FETCH_ASSOC);
-}
-
-// Mark message as read
-if (!empty($_POST['mark_read'])) {
-    $messageId = isset($_POST['message_id']) ? (int)$_POST['message_id'] : 0;
-    if ($messageId <= 0) {
-        header('Location: index.php');
-        exit;
+    try {
+        return new PDO(
+            "mysql:host={$config['DB_HOST']};dbname={$config['DB_NAME']};charset=utf8mb4",
+            $config['DB_USER'],
+            $config['DB_PASS'],
+            [PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION]
+        );
+    } catch (PDOException $e) {
+        die('DB connection failed: ' . htmlspecialchars($e->getMessage()));
     }
+}
+
+// Create beta_messages table if not exists
+try {
     $pdo = getPDO();
-    $stmt = $pdo->prepare('UPDATE beta_messages SET is_read = 1 WHERE id = ? AND to_customer_email = ?');
-    $stmt->execute([$messageId, $customer['email']]);
-    header('Location: index.php');
+    $pdo->exec("CREATE TABLE IF NOT EXISTS beta_messages (
+        id INT AUTO_INCREMENT PRIMARY KEY,
+        from_admin BOOLEAN DEFAULT TRUE,
+        to_customer_email VARCHAR(100) NOT NULL,
+        message_text TEXT NOT NULL,
+        message_type ENUM('info', 'success', 'warning', 'question') DEFAULT 'info',
+        is_read BOOLEAN DEFAULT FALSE,
+        created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+        
+        INDEX idx_customer_email (to_customer_email),
+        INDEX idx_unread (is_read, to_customer_email),
+        INDEX idx_created (created_at)
+    )");
+} catch (Exception $e) {
+    die('Beta table creation failed: ' . htmlspecialchars($e->getMessage()));
+}
+
+// Check if user is logged in first
+if (empty($_SESSION['customer_id']) || empty($_SESSION['session_authenticated'])) {
+    echo '<!DOCTYPE html>
+    <html><head><meta charset="UTF-8"><title>Beta Login Required</title></head>
+    <body style="font-family:Arial;text-align:center;padding:3rem;background:#f8fafc">
+        <h1>🧪 Beta App</h1>
+        <p>Bitte zuerst <a href="../login.php">einloggen</a> um die Beta-Funktionen zu nutzen.</p>
+        <div style="margin:2rem;padding:1rem;background:#fff3cd;border-radius:8px;color:#856404">
+            <strong>Debug Info:</strong><br>
+            Session ID: ' . session_id() . '<br>
+            Customer ID: ' . ($_SESSION['customer_id'] ?? 'not set') . '<br>
+            Authenticated: ' . ($_SESSION['session_authenticated'] ?? 'false') . '
+        </div>
+    </body></html>';
     exit;
 }
 
-$messages = getUnreadMessages($customer['email']);
+// Get customer from database
+$stmt = $pdo->prepare('SELECT * FROM customers WHERE id = ?');
+$stmt->execute([$_SESSION['customer_id']]);
+$customer = $stmt->fetch(PDO::FETCH_ASSOC);
+
+if (!$customer) {
+    session_destroy();
+    die('Customer not found in database. Please login again.');
+}
+
+// BETA ACCESS CHECK - Only for test user
+if ($customer['email'] !== 'marcus@einfachstarten.jetzt') {
+    echo '<!DOCTYPE html>
+    <html><head><meta charset="UTF-8"><title>Beta Access</title></head>
+    <body style="font-family:Arial;text-align:center;padding:3rem;background:#f8fafc">
+        <h1>🧪 Beta Access</h1>
+        <p>Diese Beta-App ist nur für autorisierte Testuser zugänglich.</p>
+        <p>Aktueller User: <strong>' . htmlspecialchars($customer['email']) . '</strong></p>
+        <p>Benötigt: <strong>marcus@einfachstarten.jetzt</strong></p>
+        <p><a href="../customer/index.php">← Zur normalen Customer App</a></p>
+    </body></html>';
+    exit;
+}
+
+// Get unread messages for this user
+$stmt = $pdo->prepare('SELECT * FROM beta_messages WHERE to_customer_email = ? AND is_read = 0 ORDER BY created_at DESC');
+$stmt->execute([$customer['email']]);
+$messages = $stmt->fetchAll(PDO::FETCH_ASSOC);
+$icons = ['info' => 'ℹ️', 'success' => '✅', 'warning' => '⚠️', 'question' => '❓'];
+$hasMessages = !empty($messages);
+$messageListHtml = '';
+
+if ($hasMessages) {
+    foreach ($messages as $msg) {
+        $icon = $icons[$msg['message_type']] ?? 'ℹ️';
+        $messageListHtml .= '<div class="message ' . htmlspecialchars($msg['message_type']) . '">';
+        $messageTypeLabel = htmlspecialchars(ucfirst($msg['message_type']), ENT_QUOTES, 'UTF-8');
+        $messageListHtml .= '<div class="message-meta">📅 ' . date('d.m.Y H:i', strtotime($msg['created_at'])) . ' • ' . $icon . ' ' . $messageTypeLabel . '</div>';
+        $messageListHtml .= '<div class="message-text">' . nl2br(htmlspecialchars($msg['message_text'])) . '</div>';
+        $messageListHtml .= '<form method="post" style="margin:0;display:inline">';
+        $messageListHtml .= '<input type="hidden" name="message_id" value="' . (int) $msg['id'] . '">';
+        $messageListHtml .= '<input type="hidden" name="mark_read" value="1">';
+        $messageListHtml .= '<button type="submit" class="mark-read-btn">✓ Als gelesen markieren</button>';
+        $messageListHtml .= '</form>';
+        $messageListHtml .= '</div>';
+    }
+}
+
+// Handle mark as read
+if ($_POST['mark_read'] ?? false) {
+    $messageId = isset($_POST['message_id']) ? (int) $_POST['message_id'] : 0;
+    if ($messageId > 0) {
+        $stmt = $pdo->prepare('UPDATE beta_messages SET is_read = 1 WHERE id = ? AND to_customer_email = ?');
+        $stmt->execute([$messageId, $customer['email']]);
+    }
+    header('Location: index.php');
+    exit;
+}
 ?>
 <!DOCTYPE html>
 <html>
@@ -64,9 +124,11 @@ $messages = getUnreadMessages($customer['email']);
     <title>🧪 Beta Customer Dashboard</title>
     <style>
         body{font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;margin:0;background:#f8fafc}
-        .beta-banner{background:linear-gradient(135deg,#667eea,#764ba2);color:white;padding:0.75rem;text-align:center;font-weight:bold}
+        .beta-banner{background:linear-gradient(135deg,#667eea,#764ba2);color:white;padding:0.75rem;text-align:center;font-weight:bold;animation:pulse 2s infinite}
+        @keyframes pulse{0%{opacity:1}50%{opacity:0.8}100%{opacity:1}}
         .container{max-width:800px;margin:2rem auto;padding:0 1rem}
         .welcome{background:white;padding:2rem;border-radius:12px;margin-bottom:2rem;box-shadow:0 2px 8px rgba(0,0,0,0.1)}
+        .debug-info{background:#fff3cd;color:#856404;padding:1rem;border-radius:8px;margin-bottom:2rem;font-size:0.875rem}
         .messages-section{background:white;padding:2rem;border-radius:12px;margin-bottom:2rem;box-shadow:0 2px 8px rgba(0,0,0,0.1)}
         .message{border-left:4px solid #4a90b8;padding:1rem;margin:1rem 0;background:#f8f9fa;border-radius:0 8px 8px 0}
         .message.success{border-left-color:#28a745}
@@ -76,59 +138,65 @@ $messages = getUnreadMessages($customer['email']);
         .message-text{color:#1f2937;line-height:1.6}
         .mark-read-btn{background:#28a745;color:white;border:none;padding:0.25rem 0.75rem;border-radius:4px;cursor:pointer;font-size:0.75rem;margin-top:0.5rem}
         .nav-links{text-align:center;margin:2rem 0}
-        .nav-links a{color:#4a90b8;text-decoration:none;margin:0 1rem;padding:0.5rem 1rem;border:1px solid #4a90b8;border-radius:6px;transition:all 0.2s}
+        .nav-links a{color:#4a90b8;text-decoration:none;margin:0 1rem;padding:0.5rem 1rem;border:1px solid #4a90b8;border-radius:6px;transition:all 0.2s;display:inline-block}
         .nav-links a:hover{background:#4a90b8;color:white}
+        .beta-features{background:linear-gradient(135deg,#667eea,#764ba2);color:white;padding:2rem;border-radius:12px;margin:2rem 0}
     </style>
 </head>
 <body>
     <div class="beta-banner">
-        🧪 BETA VERSION - Test Features für marcus@einfachstarten.jetzt
+        🧪 BETA VERSION - Experimentelle Features für <?=htmlspecialchars($customer['email'])?>
     </div>
-
+    
     <div class="container">
-        <div class="welcome">
-            <h1>Willkommen, <?=htmlspecialchars($customer['first_name'])?>! 👋</h1>
-            <p>Du nutzt die Beta-Version mit neuen experimentellen Features.</p>
+        <div class="debug-info">
+            <strong>🔍 Debug Info:</strong><br>
+            User: <?=htmlspecialchars($customer['first_name'])?> (<?=htmlspecialchars($customer['email'])?>)<br>
+            Session: <?=session_id()?><br>
+            Ungelesene Nachrichten: <?=count($messages)?><br>
+            Timestamp: <?=date('d.m.Y H:i:s')?>
         </div>
-
-        <?php if (!empty($messages)): ?>
+        
+        <div class="welcome">
+            <h1>Willkommen in der Beta, <?=htmlspecialchars($customer['first_name'])?>! 👋</h1>
+            <p>Du nutzt die Beta-Version mit experimentellen Features. Alles hier ist Work-in-Progress!</p>
+        </div>
+        
+        <?php if ($hasMessages): ?>
         <div class="messages-section">
-            <h2>📨 Neue Nachrichten (<?=count($messages)?>)</h2>
-            <?php foreach ($messages as $msg): ?>
-            <div class="message <?=htmlspecialchars($msg['message_type'])?>">
-                <div class="message-meta">
-                    📅 <?=date('d.m.Y H:i', strtotime($msg['created_at']))?> •
-                    <?php
-                    $icons = ['info' => 'ℹ️', 'success' => '✅', 'warning' => '⚠️', 'question' => '❓'];
-                    echo $icons[$msg['message_type']] ?? 'ℹ️';
-                    ?>
-                    <?=ucfirst($msg['message_type'])?>
-                </div>
-                <div class="message-text"><?=nl2br(htmlspecialchars($msg['message_text']))?></div>
-                <form method="post" style="margin:0;display:inline">
-                    <input type="hidden" name="message_id" value="<?=htmlspecialchars($msg['id'])?>">
-                    <input type="hidden" name="mark_read" value="1">
-                    <button type="submit" class="mark-read-btn">✓ Als gelesen markieren</button>
-                </form>
-            </div>
-            <?php endforeach; ?>
+            <h2>📨 Neue Beta-Nachrichten (<?=count($messages)?>)</h2>
+            <p style="color:#6b7280;font-size:0.875rem;margin-bottom:1rem">
+                ℹ️ Diese Nachrichten kommen direkt vom Admin und sind nur in der Beta-Version sichtbar.
+            </p>
+            <?=$messageListHtml?>
         </div>
         <?php else: ?>
-        <div class="messages-section" style="text-align:center;color:#6b7280">
-            <h2>📨 Keine neuen Nachrichten</h2>
-            <p>Alle Beta-Infos sind gelesen. Schau später nochmal vorbei!</p>
+        <div class="messages-section">
+            <h2>📨 Beta-Nachrichten</h2>
+            <p style="color:#6b7280;font-style:italic">Keine ungelesenen Nachrichten. Der Admin kann dir hier Updates und Feedback-Anfragen senden.</p>
         </div>
         <?php endif; ?>
-
+        
+        <div class="beta-features">
+            <h3>🚀 Beta Features in Entwicklung</h3>
+            <ul style="margin:1rem 0;padding-left:2rem">
+                <li>✅ Admin-Messaging System</li>
+                <li>🔄 Push Notifications (coming soon)</li>
+                <li>🔄 Erweiterte Booking Features</li>
+                <li>🔄 Dark Mode</li>
+                <li>🔄 Offline Capabilities</li>
+            </ul>
+        </div>
+        
         <div class="nav-links">
-            <a href="../customer/dashboard.php">📊 Dashboard</a>
+            <a href="../customer/index.php">📊 Normal Dashboard</a>
             <a href="../customer/booking.php">📅 Termine buchen</a>
             <a href="../customer/appointments.php">📋 Meine Termine</a>
             <a href="../login.php?logout=1">🚪 Abmelden</a>
         </div>
-
+        
         <div style="text-align:center;margin:2rem 0;color:#6b7280;font-size:0.875rem">
-            <p>🧪 Beta Features werden kontinuierlich erweitert</p>
+            <p>🧪 Du hilfst beim Testen neuer Features - Vielen Dank!</p>
         </div>
     </div>
 </body>


### PR DESCRIPTION
## Summary
- harden the beta customer dashboard with robust session checks, debug output, and resilient message rendering
- automatically provision the beta message table and improve messaging workflow and validation in the admin interface

## Testing
- php -l beta/index.php
- php -l admin/beta_messaging.php

------
https://chatgpt.com/codex/tasks/task_e_68ca562eca6c8323afb7e7c0ac56a0b0