### PR TITLE
Enhance beta messaging feedback workflows

### DIFF
--- a/admin/beta_messaging.php
+++ b/admin/beta_messaging.php
@@ -1,10 +1,15 @@
 <?php
-// admin/beta_messaging.php - Korrigierter Admin Bereich
+// admin/beta_messaging.php - Beta Messaging Dashboard with Feedback Analytics
 session_start();
-if(empty($_SESSION['admin'])){header('Location: login.php');exit;}
+if (empty($_SESSION['admin'])) {
+    header('Location: login.php');
+    exit;
+}
 
-function getPDO() {
+function getPDO(): PDO
+{
     $config = require __DIR__ . '/config.php';
+
     return new PDO(
         "mysql:host={$config['DB_HOST']};dbname={$config['DB_NAME']};charset=utf8mb4",
         $config['DB_USER'],
@@ -13,151 +18,422 @@ function getPDO() {
     );
 }
 
-$pdo = getPDO();
+function ensureBetaSchema(PDO $pdo): void
+{
+    $pdo->exec("CREATE TABLE IF NOT EXISTS beta_messages (
+        id INT AUTO_INCREMENT PRIMARY KEY,
+        from_admin BOOLEAN DEFAULT TRUE,
+        to_customer_email VARCHAR(100) NOT NULL,
+        message_text TEXT NOT NULL,
+        message_type ENUM('info', 'success', 'warning', 'question') DEFAULT 'info',
+        expects_response TINYINT(1) DEFAULT 0,
+        response_question TEXT NULL,
+        is_read TINYINT(1) DEFAULT 0,
+        read_at DATETIME NULL,
+        created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+        INDEX idx_customer_email (to_customer_email),
+        INDEX idx_unread (is_read, to_customer_email),
+        INDEX idx_created (created_at)
+    ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4");
 
-// Create table automatically
-$pdo->exec("CREATE TABLE IF NOT EXISTS beta_messages (
-    id INT AUTO_INCREMENT PRIMARY KEY,
-    from_admin BOOLEAN DEFAULT TRUE,
-    to_customer_email VARCHAR(100) NOT NULL,
-    message_text TEXT NOT NULL,
-    message_type ENUM('info', 'success', 'warning', 'question') DEFAULT 'info',
-    is_read BOOLEAN DEFAULT FALSE,
-    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-    
-    INDEX idx_customer_email (to_customer_email),
-    INDEX idx_unread (is_read, to_customer_email),
-    INDEX idx_created (created_at)
-)");
+    $pdo->exec("CREATE TABLE IF NOT EXISTS beta_message_responses (
+        id INT AUTO_INCREMENT PRIMARY KEY,
+        message_id INT NOT NULL,
+        customer_email VARCHAR(100) NOT NULL,
+        response_type ENUM('yes','no') NOT NULL,
+        created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+        UNIQUE KEY uniq_response (message_id, customer_email),
+        INDEX idx_response_email (customer_email),
+        CONSTRAINT fk_beta_message_response FOREIGN KEY (message_id)
+            REFERENCES beta_messages(id) ON DELETE CASCADE
+    ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4");
 
-$success = '';
+    try {
+        $pdo->exec("ALTER TABLE beta_messages ADD COLUMN expects_response TINYINT(1) DEFAULT 0 AFTER message_type");
+    } catch (Throwable $e) {
+    }
 
-// Check if beta user exists
-$beta_user_check = $pdo->prepare('SELECT * FROM customers WHERE email = ?');
-$beta_user_check->execute(['marcus@einfachstarten.jetzt']);
-$beta_user = $beta_user_check->fetch(PDO::FETCH_ASSOC);
+    try {
+        $pdo->exec("ALTER TABLE beta_messages ADD COLUMN response_question TEXT NULL AFTER expects_response");
+    } catch (Throwable $e) {
+    }
 
-if (!$beta_user) {
-    echo '<div style="background:#f8d7da;color:#721c24;padding:1rem;border-radius:5px;margin:2rem;text-align:center">
-        ❌ Beta-User marcus@einfachstarten.jetzt nicht in der Datenbank gefunden!<br>
-        Bitte erst den User anlegen bevor das Messaging getestet wird.
-    </div>';
-    exit;
-}
+    try {
+        $pdo->exec("ALTER TABLE beta_messages ADD COLUMN read_at DATETIME NULL AFTER is_read");
+    } catch (Throwable $e) {
+    }
 
-// Send message
-if (($_POST['action'] ?? '') === 'send') {
-    $message = trim($_POST['message'] ?? '');
-    $type = $_POST['type'] ?? 'info';
-    $allowedTypes = ['info', 'success', 'warning', 'question'];
-    if ($message !== '') {
-        if (!in_array($type, $allowedTypes, true)) {
-            $type = 'info';
-        }
-        $stmt = $pdo->prepare('INSERT INTO beta_messages (to_customer_email, message_text, message_type) VALUES (?, ?, ?)');
-        $stmt->execute(['marcus@einfachstarten.jetzt', $message, $type]);
-        $success = "✅ Beta-Nachricht erfolgreich gesendet!";
+    try {
+        $pdo->exec("ALTER TABLE beta_message_responses ADD UNIQUE INDEX uniq_response (message_id, customer_email)");
+    } catch (Throwable $e) {
     }
 }
 
-// Get message history
-$messages = $pdo->prepare('SELECT * FROM beta_messages WHERE to_customer_email = ? ORDER BY created_at DESC LIMIT 20');
-$messages->execute(['marcus@einfachstarten.jetzt']);
-$message_history = $messages->fetchAll(PDO::FETCH_ASSOC);
+function computeStats(PDO $pdo, string $email): array
+{
+    $stats = [
+        'total' => 0,
+        'unread' => 0,
+        'needs_response' => 0,
+        'responses' => ['yes' => 0, 'no' => 0],
+    ];
+
+    $stmt = $pdo->prepare('SELECT COUNT(*) FROM beta_messages WHERE to_customer_email = ?');
+    $stmt->execute([$email]);
+    $stats['total'] = (int) $stmt->fetchColumn();
+
+    $stmt = $pdo->prepare('SELECT COUNT(*) FROM beta_messages WHERE to_customer_email = ? AND is_read = 0');
+    $stmt->execute([$email]);
+    $stats['unread'] = (int) $stmt->fetchColumn();
+
+    $stmt = $pdo->prepare('SELECT COUNT(*) FROM beta_messages WHERE to_customer_email = ? AND expects_response = 1');
+    $stmt->execute([$email]);
+    $stats['needs_response'] = (int) $stmt->fetchColumn();
+
+    $stmt = $pdo->prepare('SELECT response_type, COUNT(*) AS total FROM beta_message_responses WHERE customer_email = ? GROUP BY response_type');
+    $stmt->execute([$email]);
+    foreach ($stmt->fetchAll(PDO::FETCH_ASSOC) as $row) {
+        $type = $row['response_type'] ?? '';
+        $count = (int) ($row['total'] ?? 0);
+        if ($type === 'yes' || $type === 'no') {
+            $stats['responses'][$type] = $count;
+        }
+    }
+
+    return $stats;
+}
+
+try {
+    $pdo = getPDO();
+    ensureBetaSchema($pdo);
+} catch (Throwable $e) {
+    die('DB error: ' . htmlspecialchars($e->getMessage(), ENT_QUOTES, 'UTF-8'));
+}
+
+if (($_GET['export'] ?? '') === 'responses') {
+    $email = 'marcus@einfachstarten.jetzt';
+
+    header('Content-Type: text/csv; charset=utf-8');
+    header('Content-Disposition: attachment; filename="beta_responses.csv"');
+
+    $output = fopen('php://output', 'w');
+    fputcsv($output, ['Message ID', 'Frage', 'Antwort', 'Antwortdatum']);
+
+    $exportStmt = $pdo->prepare('SELECT m.id, m.response_question, r.response_type, r.created_at
+        FROM beta_message_responses r
+        JOIN beta_messages m ON m.id = r.message_id
+        WHERE r.customer_email = ?
+        ORDER BY r.created_at DESC');
+    $exportStmt->execute([$email]);
+
+    while ($row = $exportStmt->fetch(PDO::FETCH_ASSOC)) {
+        fputcsv($output, [
+            $row['id'],
+            $row['response_question'],
+            strtoupper($row['response_type']),
+            $row['created_at'],
+        ]);
+    }
+
+    fclose($output);
+    exit;
+}
+
+$betaUserStmt = $pdo->prepare('SELECT * FROM customers WHERE email = ?');
+$betaUserStmt->execute(['marcus@einfachstarten.jetzt']);
+$betaUser = $betaUserStmt->fetch(PDO::FETCH_ASSOC);
+
+if (!$betaUser) {
+    echo '<div style="background:#f8d7da;color:#721c24;padding:1rem;border-radius:5px;margin:2rem;text-align:center">'
+        . '❌ Beta-User marcus@einfachstarten.jetzt nicht gefunden. Bitte zuerst anlegen.'
+        . '</div>';
+    exit;
+}
+
+$success = '';
+$errors = [];
+$messageTemplates = [
+    'Feature Release' => "Wir haben ein neues Beta-Feature aktiviert. Kannst du es in dieser Woche testen?",
+    'Bug Check' => "Wir haben einen Fix eingespielt. Funktioniert alles wieder wie erwartet?",
+    'Usability Feedback' => "Wie intuitiv war der neue Ablauf für dich? Bitte gib uns ein Ja/Nein Feedback.",
+];
+
+if (($_POST['action'] ?? '') === 'send') {
+    $message = trim($_POST['message'] ?? '');
+    $type = $_POST['type'] ?? 'info';
+    $expectsResponse = !empty($_POST['expects_response']);
+    $responseQuestion = trim($_POST['response_question'] ?? '');
+
+    $allowedTypes = ['info', 'success', 'warning', 'question'];
+    if (!in_array($type, $allowedTypes, true)) {
+        $type = 'info';
+    }
+
+    if ($expectsResponse && $responseQuestion === '') {
+        $errors[] = 'Bitte eine Ja/Nein-Frage formulieren, wenn eine Antwort erwartet wird.';
+    }
+
+    if ($message === '') {
+        $errors[] = 'Nachrichtentext darf nicht leer sein.';
+    }
+
+    if (!$errors) {
+        $stmt = $pdo->prepare('INSERT INTO beta_messages (to_customer_email, message_text, message_type, expects_response, response_question)
+            VALUES (?, ?, ?, ?, ?)');
+        $stmt->execute([
+            $betaUser['email'],
+            $message,
+            $type,
+            $expectsResponse ? 1 : 0,
+            $expectsResponse ? $responseQuestion : null,
+        ]);
+        $success = '✅ Beta-Nachricht erfolgreich gesendet!';
+    }
+}
+
+$stats = computeStats($pdo, $betaUser['email']);
+$messagesStmt = $pdo->prepare('SELECT m.*, r.response_type, r.created_at AS responded_at
+    FROM beta_messages m
+    LEFT JOIN beta_message_responses r ON r.message_id = m.id AND r.customer_email = ?
+    WHERE m.to_customer_email = ?
+    ORDER BY m.created_at DESC
+    LIMIT 50');
+$messagesStmt->execute([$betaUser['email'], $betaUser['email']]);
+$messageHistory = $messagesStmt->fetchAll(PDO::FETCH_ASSOC);
+
+$responseTimelineStmt = $pdo->prepare('SELECT r.*, m.message_text, m.response_question
+    FROM beta_message_responses r
+    JOIN beta_messages m ON m.id = r.message_id
+    WHERE r.customer_email = ?
+    ORDER BY r.created_at DESC
+    LIMIT 20');
+$responseTimelineStmt->execute([$betaUser['email']]);
+$responseTimeline = $responseTimelineStmt->fetchAll(PDO::FETCH_ASSOC);
+
+$totalResponses = array_sum($stats['responses']);
+$yesPercent = $totalResponses > 0 ? round(($stats['responses']['yes'] / $totalResponses) * 100) : 0;
+$noPercent = $totalResponses > 0 ? round(($stats['responses']['no'] / $totalResponses) * 100) : 0;
+$engagementRate = $stats['needs_response'] > 0 ? round(($totalResponses / $stats['needs_response']) * 100, 1) : 0;
 ?>
 <!DOCTYPE html>
-<html>
+<html lang="de">
 <head>
     <meta charset="UTF-8">
-    <title>🧪 Beta Messaging</title>
+    <title>🧪 Beta Messaging Dashboard</title>
     <style>
-        body{font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;margin:2rem;background:#f8fafc}
-        .container{max-width:900px;margin:0 auto}
-        .header{background:linear-gradient(135deg,#667eea,#764ba2);color:white;padding:2rem;border-radius:12px;margin-bottom:2rem;text-align:center}
-        .send-form{background:white;padding:2rem;border-radius:12px;margin-bottom:2rem;box-shadow:0 2px 8px rgba(0,0,0,0.1)}
-        .history{background:white;padding:2rem;border-radius:12px;box-shadow:0 2px 8px rgba(0,0,0,0.1)}
-        .message{border-left:4px solid #4a90b8;padding:1rem;margin:1rem 0;background:#f8f9fa;border-radius:0 8px 8px 0}
-        .message.read{opacity:0.7}
-        .success{background:#d4edda;color:#155724;padding:1rem;border-radius:5px;margin:1rem 0}
-        select,textarea,button{padding:0.75rem;margin:0.5rem 0;border-radius:6px;border:1px solid #d1d5db;font-family:inherit}
-        button{background:#4a90b8;color:white;border:none;cursor:pointer;font-weight:500;transition:all 0.2s}
-        button:hover{background:#2563eb;transform:translateY(-1px)}
-        textarea{width:100%;min-height:120px;resize:vertical}
-        .beta-badge{background:linear-gradient(135deg,#667eea,#764ba2);color:white;padding:0.5rem 1rem;border-radius:20px;font-size:0.875rem;font-weight:bold}
-        .user-info{background:#e3f2fd;padding:1rem;border-radius:8px;margin:1rem 0}
+        body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; margin: 2rem; background: #f8fafc; color: #1f2937; }
+        a { color: #4a90b8; }
+        .container { max-width: 1100px; margin: 0 auto; }
+        .header { background: linear-gradient(135deg,#667eea,#764ba2); color: white; padding: 2rem; border-radius: 16px; margin-bottom: 2rem; }
+        .grid { display: grid; gap: 1.25rem; }
+        .grid-3 { grid-template-columns: repeat(auto-fit, minmax(240px, 1fr)); }
+        .grid-2 { grid-template-columns: repeat(auto-fit, minmax(320px, 1fr)); }
+        .card { background: white; border-radius: 14px; padding: 1.25rem; box-shadow: 0 8px 24px rgba(15, 23, 42, 0.08); border: 1px solid rgba(148, 163, 184, 0.2); }
+        .card h3 { margin-bottom: 0.75rem; display: flex; align-items: center; gap: 0.5rem; font-size: 1.05rem; }
+        .badge { display: inline-block; padding: 0.25rem 0.75rem; border-radius: 999px; font-size: 0.75rem; font-weight: 600; }
+        .badge-info { background: rgba(59,130,246,0.1); color: #2563eb; }
+        .badge-success { background: rgba(16,185,129,0.1); color: #059669; }
+        .badge-warning { background: rgba(245,158,11,0.12); color: #d97706; }
+        .badge-danger { background: rgba(239,68,68,0.12); color: #dc2626; }
+        .stat { display: flex; align-items: baseline; gap: 0.5rem; }
+        .stat strong { font-size: 1.75rem; }
+        .form-group { margin-bottom: 1rem; }
+        label { display: block; font-weight: 600; margin-bottom: 0.35rem; }
+        textarea { width: 100%; min-height: 140px; border-radius: 10px; border: 1px solid #cbd5f5; padding: 0.75rem; font: inherit; }
+        select, input[type="text"] { width: 100%; border-radius: 10px; border: 1px solid #cbd5f5; padding: 0.65rem; font: inherit; }
+        button { background: #4a90b8; color: white; border: none; border-radius: 10px; padding: 0.75rem 1.5rem; font-size: 1rem; cursor: pointer; box-shadow: 0 8px 16px rgba(74, 144, 184, 0.2); }
+        button:hover { background: #2563eb; }
+        .success { background: #dcfce7; color: #166534; padding: 1rem; border-radius: 12px; margin-bottom: 1.5rem; border: 1px solid #bbf7d0; }
+        .error { background: #fee2e2; color: #b91c1c; padding: 1rem; border-radius: 12px; margin-bottom: 1.5rem; border: 1px solid #fecaca; }
+        .history-item { border-left: 3px solid #4a90b8; padding-left: 1rem; margin-bottom: 1rem; }
+        .history-item p { margin: 0.25rem 0; }
+        .timeline { border-left: 2px solid #cbd5f5; padding-left: 1rem; }
+        .timeline-entry { position: relative; margin-bottom: 1rem; padding-left: 0.5rem; }
+        .timeline-entry::before { content: ''; position: absolute; left: -1.25rem; top: 0.5rem; width: 0.75rem; height: 0.75rem; border-radius: 50%; background: #4a90b8; }
+        .template-select { display: flex; gap: 0.75rem; align-items: center; }
+        .template-select select { flex: 1; }
+        .actions { display: flex; gap: 0.75rem; flex-wrap: wrap; margin-bottom: 1.5rem; }
+        .actions a { text-decoration: none; }
+        .pill { padding: 0.4rem 0.9rem; border-radius: 999px; background: rgba(148, 163, 184, 0.15); font-size: 0.8rem; }
+        @media (max-width: 768px) { body { margin: 1rem; } }
     </style>
 </head>
 <body>
 <div class="container">
     <div class="header">
         <h1>🧪 Beta Messaging System</h1>
-        <p>Direkter Kommunikationskanal mit Beta-Usern</p>
+        <p>Strukturiertes Feedback sammeln, Nachrichten verwalten und Tester-Engagement messen.</p>
     </div>
-    
+
     <p><a href="dashboard.php">← Zurück zum Dashboard</a></p>
-    
-    <div class="user-info">
-        <strong>Beta-User Status:</strong><br>
-        Name: <?=htmlspecialchars($beta_user['first_name'] . ' ' . $beta_user['last_name'])?><br>
-        Email: <?=htmlspecialchars($beta_user['email'])?><br>
-        Status: <?=htmlspecialchars($beta_user['status'])?><br>
-        Registriert: <?=htmlspecialchars($beta_user['created_at'])?>
+    <div class="actions">
+        <span class="pill">Beta-Tester: <?= htmlspecialchars($betaUser['first_name'] . ' ' . $betaUser['last_name']) ?></span>
+        <span class="pill">Status: <?= htmlspecialchars($betaUser['status']) ?></span>
+        <span class="pill">Registriert am <?= htmlspecialchars($betaUser['created_at']) ?></span>
+        <a class="pill" href="?export=responses">⬇️ Responses exportieren</a>
     </div>
-    
-    <?php if(!empty($success)): ?>
-        <div class="success"><?=$success?></div>
+
+    <?php if ($success): ?>
+        <div class="success"><?= htmlspecialchars($success) ?></div>
     <?php endif; ?>
-    
-    <div class="send-form">
+
+    <?php if ($errors): ?>
+        <div class="error">
+            <strong>Bitte prüfen:</strong>
+            <ul>
+                <?php foreach ($errors as $error): ?>
+                    <li><?= htmlspecialchars($error) ?></li>
+                <?php endforeach; ?>
+            </ul>
+        </div>
+    <?php endif; ?>
+
+    <div class="grid grid-3" style="margin-bottom:1.5rem;">
+        <div class="card">
+            <h3>📬 Nachrichten gesamt</h3>
+            <div class="stat"><strong><?= $stats['total'] ?></strong><span>gesendet</span></div>
+            <span class="badge badge-info">📥 Davon <?= $stats['unread'] ?> ungelesen</span>
+        </div>
+        <div class="card">
+            <h3>❓ Feedback erwartet</h3>
+            <div class="stat"><strong><?= $stats['needs_response'] ?></strong><span>Fragen aktiv</span></div>
+            <span class="badge badge-warning">Engagement: <?= $engagementRate ?>%</span>
+        </div>
+        <div class="card">
+            <h3>✅ Response-Quote</h3>
+            <div class="stat"><strong><?= $totalResponses ?></strong><span>Antworten</span></div>
+            <span class="badge badge-success">Ja: <?= $yesPercent ?>% • Nein: <?= $noPercent ?>%</span>
+        </div>
+    </div>
+
+    <div class="card" style="margin-bottom:2rem;">
         <h3>📤 Nachricht an Beta-User senden</h3>
         <form method="post">
             <input type="hidden" name="action" value="send">
-            
-            <p><strong>Empfänger:</strong> <?=htmlspecialchars($beta_user['first_name'])?> (marcus@einfachstarten.jetzt)</p>
-            
-            <select name="type" style="width:250px">
-                <option value="info">ℹ️ Information/Update</option>
-                <option value="success">✅ Erfolg/Bestätigung</option>
-                <option value="warning">⚠️ Warnung/Wichtiger Hinweis</option>
-                <option value="question">❓ Frage/Feedback benötigt</option>
-            </select>
-            
-            <textarea name="message" placeholder="Beta-Nachricht eingeben... 
 
-Beispiele:
-- Neues Feature xyz ist verfügbar zum Testen
-- Bitte teste die neue Booking-Funktion und gib Feedback
-- Warnung: Beta-System wird morgen um 14:00 neu gestartet" required></textarea>
-            
-            <button type="submit">📨 Beta-Nachricht senden</button>
+            <div class="form-group">
+                <label for="messageType">Nachrichten-Typ</label>
+                <select name="type" id="messageType">
+                    <option value="info">ℹ️ Information</option>
+                    <option value="success">✅ Erfolg</option>
+                    <option value="warning">⚠️ Hinweis/Warnung</option>
+                    <option value="question">❓ Feedback-Frage</option>
+                </select>
+            </div>
+
+            <div class="form-group template-select">
+                <label for="templateSelect" style="margin-bottom:0;">Vorlage</label>
+                <select id="templateSelect">
+                    <option value="">— Vorlage auswählen —</option>
+                    <?php foreach ($messageTemplates as $label => $template): ?>
+                        <option value="<?= htmlspecialchars($template) ?>"><?= htmlspecialchars($label) ?></option>
+                    <?php endforeach; ?>
+                </select>
+                <button type="button" id="applyTemplate" style="padding:0.6rem 1rem;">Übernehmen</button>
+            </div>
+
+            <div class="form-group">
+                <label for="messageText">Nachricht</label>
+                <textarea name="message" id="messageText" placeholder="Beta-Nachricht eingeben..."></textarea>
+            </div>
+
+            <div class="form-group">
+                <label><input type="checkbox" name="expects_response" id="expectsResponse"> Ja/Nein Antwort einfordern</label>
+                <input type="text" name="response_question" id="responseQuestion" placeholder="Welche Frage soll beantwortet werden?" style="display:none;margin-top:0.5rem;">
+            </div>
+
+            <button type="submit">📨 Nachricht senden</button>
         </form>
     </div>
-    
-    <div class="history">
-        <h3>📋 Nachrichten-Verlauf (<?=count($message_history)?>)</h3>
-        <?php if(empty($message_history)): ?>
-            <p style="color:#6b7280;font-style:italic">Noch keine Nachrichten gesendet. Schicke die erste Beta-Nachricht!</p>
+    <div class="grid grid-2" style="margin-bottom:2rem;">
+        <div class="card">
+            <h3>📈 Response-Statistiken</h3>
+            <p>Verteilung der Ja/Nein-Antworten inkl. Engagement-Quote.</p>
+            <ul style="list-style:none;padding:0;margin:1rem 0;display:flex;flex-direction:column;gap:0.5rem;">
+                <li><span class="badge badge-success">✅ Ja</span> <?= $stats['responses']['yes'] ?> Antworten</li>
+                <li><span class="badge badge-danger">❌ Nein</span> <?= $stats['responses']['no'] ?> Antworten</li>
+                <li><span class="badge badge-warning">📊 Engagement</span> <?= $engagementRate ?>% aller Fragen beantwortet</li>
+            </ul>
+            <p style="font-size:0.85rem;color:#6b7280;">Die Engagement-Quote berechnet sich aus gesendeten Antworten im Verhältnis zu allen Fragen, die eine Rückmeldung erwarten.</p>
+        </div>
+
+        <div class="card">
+            <h3>🧾 Response-Zeitleiste</h3>
+            <?php if (!$responseTimeline): ?>
+                <p style="color:#6b7280;">Noch keine Antworten eingegangen.</p>
+            <?php else: ?>
+                <div class="timeline">
+                    <?php foreach ($responseTimeline as $entry): ?>
+                        <div class="timeline-entry">
+                            <div style="font-weight:600;">Antwort: <?= strtoupper(htmlspecialchars($entry['response_type'])) ?></div>
+                            <div style="font-size:0.85rem; margin:0.25rem 0;">Frage: <?= htmlspecialchars($entry['response_question'] ?? '—') ?></div>
+                            <div style="font-size:0.8rem;color:#64748b;"><?= htmlspecialchars($entry['created_at']) ?></div>
+                        </div>
+                    <?php endforeach; ?>
+                </div>
+            <?php endif; ?>
+        </div>
+    </div>
+
+    <div class="card">
+        <h3>🗂️ Nachrichten-Historie</h3>
+        <?php if (!$messageHistory): ?>
+            <p style="color:#6b7280;">Es wurden noch keine Beta-Nachrichten verschickt.</p>
         <?php else: ?>
-            <?php foreach($message_history as $msg): ?>
-            <div class="message <?=$msg['is_read'] ? 'read' : ''?>">
-                <div style="display:flex;justify-content:space-between;align-items:center;margin-bottom:0.5rem">
-                    <span style="font-size:0.875rem;color:#6b7280">
-                        <?=date('d.m.Y H:i', strtotime($msg['created_at']))?> • 
+            <?php foreach ($messageHistory as $msg): ?>
+                <div class="history-item">
+                    <p style="font-size:0.8rem;color:#6b7280;">
+                        <?= date('d.m.Y H:i', strtotime($msg['created_at'])) ?> •
                         <?php
                         $icons = ['info' => 'ℹ️', 'success' => '✅', 'warning' => '⚠️', 'question' => '❓'];
                         echo $icons[$msg['message_type']] ?? 'ℹ️';
-                        ?>
-                        <?=ucfirst($msg['message_type'])?>
-                    </span>
-                    <span style="font-size:0.75rem;color:<?=$msg['is_read'] ? '#28a745' : '#dc3545'?>;font-weight:bold">
-                        <?=$msg['is_read'] ? '✓ GELESEN' : '● UNGELESEN'?>
-                    </span>
+                        ?> <?= strtoupper(htmlspecialchars($msg['message_type'])) ?>
+                        <?= $msg['is_read'] ? '• ✓ gelesen' : '• ● ungelesen' ?>
+                    </p>
+                    <p><?= nl2br(htmlspecialchars($msg['message_text'])) ?></p>
+                    <?php if (!empty($msg['expects_response'])): ?>
+                        <p><strong>Frage:</strong> <?= htmlspecialchars($msg['response_question'] ?? '') ?></p>
+                        <p><strong>Antwort:</strong>
+                            <?php if ($msg['response_type']): ?>
+                                <?= strtoupper(htmlspecialchars($msg['response_type'])) ?> am <?= htmlspecialchars($msg['responded_at']) ?>
+                            <?php else: ?>
+                                <span style="color:#d97706;">Wartet auf Feedback</span>
+                            <?php endif; ?>
+                        </p>
+                    <?php endif; ?>
                 </div>
-                <div><?=nl2br(htmlspecialchars($msg['message_text']))?></div>
-            </div>
             <?php endforeach; ?>
         <?php endif; ?>
     </div>
 </div>
+
+<script>
+    const expectsResponseCheckbox = document.getElementById('expectsResponse');
+    const responseQuestionInput = document.getElementById('responseQuestion');
+    const templateSelect = document.getElementById('templateSelect');
+    const applyTemplateButton = document.getElementById('applyTemplate');
+    const messageText = document.getElementById('messageText');
+
+    function toggleResponseQuestion() {
+        if (expectsResponseCheckbox.checked) {
+            responseQuestionInput.style.display = 'block';
+            responseQuestionInput.required = true;
+        } else {
+            responseQuestionInput.style.display = 'none';
+            responseQuestionInput.required = false;
+            responseQuestionInput.value = '';
+        }
+    }
+
+    expectsResponseCheckbox.addEventListener('change', toggleResponseQuestion);
+    toggleResponseQuestion();
+
+    applyTemplateButton.addEventListener('click', () => {
+        const template = templateSelect.value;
+        if (template) {
+            messageText.value = template;
+        }
+    });
+</script>
 </body>
 </html>

--- a/beta/index.php
+++ b/beta/index.php
@@ -1,5 +1,5 @@
 <?php
-// beta/index.php - Enhanced Beta Customer App with Live Messaging
+// beta/index.php - Enhanced Beta Customer App with Live Messaging and Feedback Panel
 ini_set('display_errors', 1);
 error_reporting(E_ALL);
 
@@ -9,34 +9,283 @@ function getPDO(): PDO
 {
     $config = require __DIR__ . '/../admin/config.php';
 
-    try {
-        return new PDO(
-            "mysql:host={$config['DB_HOST']};dbname={$config['DB_NAME']};charset=utf8mb4",
-            $config['DB_USER'],
-            $config['DB_PASS'],
-            [PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION]
-        );
-    } catch (PDOException $e) {
-        die('DB connection failed: ' . htmlspecialchars($e->getMessage(), ENT_QUOTES, 'UTF-8'));
-    }
+    return new PDO(
+        "mysql:host={$config['DB_HOST']};dbname={$config['DB_NAME']};charset=utf8mb4",
+        $config['DB_USER'],
+        $config['DB_PASS'],
+        [PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION]
+    );
 }
 
-try {
-    $pdo = getPDO();
+function ensureBetaSchema(PDO $pdo): void
+{
     $pdo->exec("CREATE TABLE IF NOT EXISTS beta_messages (
         id INT AUTO_INCREMENT PRIMARY KEY,
         from_admin BOOLEAN DEFAULT TRUE,
         to_customer_email VARCHAR(100) NOT NULL,
         message_text TEXT NOT NULL,
         message_type ENUM('info', 'success', 'warning', 'question') DEFAULT 'info',
-        is_read BOOLEAN DEFAULT FALSE,
+        expects_response TINYINT(1) DEFAULT 0,
+        response_question TEXT NULL,
+        is_read TINYINT(1) DEFAULT 0,
+        read_at DATETIME NULL,
         created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
         INDEX idx_customer_email (to_customer_email),
         INDEX idx_unread (is_read, to_customer_email),
         INDEX idx_created (created_at)
-    ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;");
+    ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4");
+
+    $pdo->exec("CREATE TABLE IF NOT EXISTS beta_message_responses (
+        id INT AUTO_INCREMENT PRIMARY KEY,
+        message_id INT NOT NULL,
+        customer_email VARCHAR(100) NOT NULL,
+        response_type ENUM('yes','no') NOT NULL,
+        created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+        UNIQUE KEY uniq_response (message_id, customer_email),
+        INDEX idx_response_email (customer_email),
+        CONSTRAINT fk_message_response_beta FOREIGN KEY (message_id)
+            REFERENCES beta_messages(id) ON DELETE CASCADE
+    ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4");
+
+    try {
+        $pdo->exec("ALTER TABLE beta_messages ADD COLUMN expects_response TINYINT(1) DEFAULT 0 AFTER message_type");
+    } catch (Throwable $e) {
+    }
+
+    try {
+        $pdo->exec("ALTER TABLE beta_messages ADD COLUMN response_question TEXT NULL AFTER expects_response");
+    } catch (Throwable $e) {
+    }
+
+    try {
+        $pdo->exec("ALTER TABLE beta_messages ADD COLUMN read_at DATETIME NULL AFTER is_read");
+    } catch (Throwable $e) {
+    }
+
+    try {
+        $pdo->exec("ALTER TABLE beta_message_responses ADD UNIQUE INDEX uniq_response (message_id, customer_email)");
+    } catch (Throwable $e) {
+    }
+}
+
+function transformMessageRow(array $row): array
+{
+    return [
+        'id' => (int) ($row['id'] ?? 0),
+        'message_text' => (string) ($row['message_text'] ?? ''),
+        'message_type' => (string) ($row['message_type'] ?? 'info'),
+        'is_read' => !empty($row['is_read']),
+        'created_at' => $row['created_at'] ?? null,
+        'read_at' => $row['read_at'] ?? null,
+        'expects_response' => !empty($row['expects_response']),
+        'response_question' => (string) ($row['response_question'] ?? ''),
+        'user_response' => $row['response_type'] ?? null,
+        'responded_at' => $row['response_created_at'] ?? null,
+    ];
+}
+
+function fetchMessages(PDO $pdo, string $email, string $mode = 'all', int $limit = 40): array
+{
+    $conditions = 'm.to_customer_email = ?';
+    if ($mode === 'unread') {
+        $conditions .= ' AND m.is_read = 0';
+    } elseif ($mode === 'read') {
+        $conditions .= ' AND m.is_read = 1';
+    }
+
+    $sql = "SELECT m.*, r.response_type, r.created_at AS response_created_at
+            FROM beta_messages m
+            LEFT JOIN beta_message_responses r
+                ON r.message_id = m.id AND r.customer_email = ?
+            WHERE {$conditions}
+            ORDER BY m.created_at DESC";
+
+    if ($limit > 0) {
+        $sql .= ' LIMIT ' . (int) $limit;
+    }
+
+    $stmt = $pdo->prepare($sql);
+    $stmt->execute([$email, $email]);
+    $rows = $stmt->fetchAll(PDO::FETCH_ASSOC);
+
+    return array_map('transformMessageRow', $rows);
+}
+
+function computeMessageStats(PDO $pdo, string $email): array
+{
+    $stats = [
+        'total' => 0,
+        'unread' => 0,
+        'read' => 0,
+        'needs_response' => 0,
+        'responses_submitted' => 0,
+        'response_breakdown' => ['yes' => 0, 'no' => 0],
+    ];
+
+    $stmt = $pdo->prepare('SELECT COUNT(*) FROM beta_messages WHERE to_customer_email = ?');
+    $stmt->execute([$email]);
+    $stats['total'] = (int) $stmt->fetchColumn();
+
+    $stmt = $pdo->prepare('SELECT COUNT(*) FROM beta_messages WHERE to_customer_email = ? AND is_read = 0');
+    $stmt->execute([$email]);
+    $stats['unread'] = (int) $stmt->fetchColumn();
+
+    $stats['read'] = max(0, $stats['total'] - $stats['unread']);
+
+    $stmt = $pdo->prepare('SELECT COUNT(*) FROM beta_messages WHERE to_customer_email = ? AND expects_response = 1');
+    $stmt->execute([$email]);
+    $stats['needs_response'] = (int) $stmt->fetchColumn();
+
+    $stmt = $pdo->prepare('SELECT response_type, COUNT(*) AS total FROM beta_message_responses WHERE customer_email = ? GROUP BY response_type');
+    $stmt->execute([$email]);
+    foreach ($stmt->fetchAll(PDO::FETCH_ASSOC) as $row) {
+        $type = $row['response_type'] ?? '';
+        $count = (int) ($row['total'] ?? 0);
+        if ($type === 'yes' || $type === 'no') {
+            $stats['response_breakdown'][$type] = $count;
+        }
+    }
+
+    $stats['responses_submitted'] = array_sum($stats['response_breakdown']);
+
+    return $stats;
+}
+function calculateTestingStreak(PDO $pdo, string $email): int
+{
+    $stmt = $pdo->prepare('SELECT DISTINCT DATE(created_at) AS activity_day FROM beta_message_responses WHERE customer_email = ? ORDER BY activity_day DESC');
+    $stmt->execute([$email]);
+    $dates = $stmt->fetchAll(PDO::FETCH_COLUMN);
+
+    if (!$dates) {
+        return 0;
+    }
+
+    $today = new DateTime('today');
+    $streak = 0;
+
+    while (true) {
+        $dayKey = $today->format('Y-m-d');
+        if (in_array($dayKey, $dates, true)) {
+            $streak++;
+            $today->modify('-1 day');
+        } else {
+            break;
+        }
+    }
+
+    return $streak;
+}
+
+function computeBetaStatus(PDO $pdo, string $email): array
+{
+    $stats = computeMessageStats($pdo, $email);
+    $recentMessages = fetchMessages($pdo, $email, 'all', 15);
+
+    $engagementRate = $stats['needs_response'] > 0
+        ? round(($stats['responses_submitted'] / $stats['needs_response']) * 100, 1)
+        : 0.0;
+
+    $progress = $stats['total'] > 0
+        ? (int) min(100, round(($stats['read'] / max(1, $stats['total'])) * 60 + ($engagementRate / 100) * 40))
+        : 0;
+
+    $featureUsage = [];
+    $usageStmt = $pdo->prepare('SELECT message_type, COUNT(*) AS total FROM beta_messages WHERE to_customer_email = ? GROUP BY message_type');
+    $usageStmt->execute([$email]);
+    foreach ($usageStmt->fetchAll(PDO::FETCH_ASSOC) as $row) {
+        $featureUsage[] = [
+            'label' => ucfirst($row['message_type'] ?? 'Info'),
+            'count' => (int) ($row['total'] ?? 0),
+        ];
+    }
+
+    $timeline = [];
+    foreach ($recentMessages as $message) {
+        $timeline[] = [
+            'id' => $message['id'],
+            'title' => mb_strimwidth($message['message_text'], 0, 80, '…', 'UTF-8'),
+            'status' => $message['expects_response']
+                ? ($message['user_response'] ? 'Feedback gegeben' : 'Wartet auf Feedback')
+                : 'Abgeschlossen',
+            'response' => $message['user_response'],
+            'created_at' => $message['created_at'],
+            'read_at' => $message['read_at'],
+        ];
+    }
+
+    return [
+        'stats' => $stats,
+        'progress' => $progress,
+        'engagement_rate' => $engagementRate,
+        'testing_streak' => calculateTestingStreak($pdo, $email),
+        'feature_usage' => $featureUsage,
+        'recent_features' => $timeline,
+    ];
+}
+
+function fetchSessionHistory(PDO $pdo, int $customerId, int $limit = 6): array
+{
+    try {
+        $stmt = $pdo->prepare('SELECT created_at, expires_at FROM customer_sessions WHERE customer_id = ? ORDER BY created_at DESC LIMIT ' . (int) $limit);
+        $stmt->execute([$customerId]);
+
+        return $stmt->fetchAll(PDO::FETCH_ASSOC);
+    } catch (Throwable $e) {
+        return [];
+    }
+}
+
+function fetchActivityFeed(PDO $pdo, string $email, int $limit = 15): array
+{
+    $messages = fetchMessages($pdo, $email, 'all', $limit * 2);
+    $feed = [];
+
+    foreach ($messages as $message) {
+        $feed[] = [
+            'type' => 'message',
+            'title' => 'Neue Beta-Nachricht',
+            'details' => mb_strimwidth($message['message_text'], 0, 100, '…', 'UTF-8'),
+            'timestamp' => $message['created_at'],
+            'meta' => $message['message_type'],
+        ];
+
+        if (!empty($message['read_at'])) {
+            $feed[] = [
+                'type' => 'read',
+                'title' => 'Nachricht gelesen',
+                'details' => 'Status aktualisiert',
+                'timestamp' => $message['read_at'],
+                'meta' => $message['message_type'],
+            ];
+        }
+
+        if (!empty($message['user_response'])) {
+            $feed[] = [
+                'type' => 'response',
+                'title' => 'Feedback gesendet',
+                'details' => strtoupper($message['user_response']) . ' Antwort übermittelt',
+                'timestamp' => $message['responded_at'],
+                'meta' => $message['message_type'],
+            ];
+        }
+    }
+
+    usort($feed, static function ($a, $b) {
+        return strcmp($b['timestamp'] ?? '', $a['timestamp'] ?? '');
+    });
+
+    return array_slice($feed, 0, $limit);
+}
+
+try {
+    $pdo = getPDO();
+    ensureBetaSchema($pdo);
 } catch (Throwable $e) {
     die('Beta table creation failed: ' . htmlspecialchars($e->getMessage(), ENT_QUOTES, 'UTF-8'));
+}
+
+if (empty($_SESSION['session_start_time'])) {
+    $_SESSION['session_start_time'] = time();
 }
 
 if (empty($_SESSION['customer_id']) || empty($_SESSION['session_authenticated'])) {
@@ -53,7 +302,7 @@ if (!$customer) {
     die('Customer not found. Please login again.');
 }
 
-if ($customer['email'] !== 'marcus@einfachstarten.jetzt') {
+if (($customer['email'] ?? '') !== 'marcus@einfachstarten.jetzt') {
     echo '<!DOCTYPE html>'
         . '<html><head><meta charset="UTF-8"><title>Beta Access</title></head>'
         . '<body style="font-family:Arial;text-align:center;padding:3rem;background:#f8fafc">'
@@ -68,7 +317,7 @@ if (!empty($_POST['mark_read'])) {
     $messageId = isset($_POST['message_id']) ? (int) $_POST['message_id'] : 0;
 
     if ($messageId > 0) {
-        $stmt = $pdo->prepare('UPDATE beta_messages SET is_read = 1 WHERE id = ? AND to_customer_email = ?');
+        $stmt = $pdo->prepare('UPDATE beta_messages SET is_read = 1, read_at = COALESCE(read_at, NOW()) WHERE id = ? AND to_customer_email = ?');
         $stmt->execute([$messageId, $customer['email']]);
     }
 
@@ -77,36 +326,112 @@ if (!empty($_POST['mark_read'])) {
     exit;
 }
 
-if (!empty($_GET['ajax'])) {
-    $stmt = $pdo->prepare('SELECT COUNT(*) FROM beta_messages WHERE to_customer_email = ? AND is_read = 0');
-    $stmt->execute([$customer['email']]);
-    $unreadCount = (int) $stmt->fetchColumn();
-
-    $stmt = $pdo->prepare('SELECT id, message_text, message_type, created_at FROM beta_messages WHERE to_customer_email = ? AND is_read = 0 ORDER BY created_at DESC LIMIT 10');
-    $stmt->execute([$customer['email']]);
-
-    $unreadMessages = [];
-
-    while ($row = $stmt->fetch(PDO::FETCH_ASSOC)) {
-        $unreadMessages[] = [
-            'id' => (int) $row['id'],
-            'message_text' => htmlspecialchars($row['message_text'], ENT_QUOTES, 'UTF-8'),
-            'message_type' => htmlspecialchars($row['message_type'], ENT_QUOTES, 'UTF-8'),
-            'created_at' => $row['created_at'],
-        ];
-    }
+if (!empty($_POST['respond_to_message'])) {
+    $messageId = isset($_POST['message_id']) ? (int) $_POST['message_id'] : 0;
+    $responseType = isset($_POST['response_type']) ? strtolower((string) $_POST['response_type']) : '';
 
     header('Content-Type: application/json');
-    echo json_encode([
-        'unread_count' => $unreadCount,
-        'messages' => $unreadMessages,
-    ]);
+
+    if ($messageId <= 0 || !in_array($responseType, ['yes', 'no'], true)) {
+        echo json_encode(['success' => false, 'error' => 'Ungültige Antwort.']);
+        exit;
+    }
+
+    $stmt = $pdo->prepare('SELECT id FROM beta_messages WHERE id = ? AND to_customer_email = ?');
+    $stmt->execute([$messageId, $customer['email']]);
+    $message = $stmt->fetch(PDO::FETCH_ASSOC);
+
+    if (!$message) {
+        echo json_encode(['success' => false, 'error' => 'Nachricht nicht gefunden.']);
+        exit;
+    }
+
+    try {
+        $pdo->beginTransaction();
+
+        $insert = $pdo->prepare('INSERT INTO beta_message_responses (message_id, customer_email, response_type)
+            VALUES (?, ?, ?) ON DUPLICATE KEY UPDATE response_type = VALUES(response_type), created_at = CURRENT_TIMESTAMP');
+        $insert->execute([$messageId, $customer['email'], $responseType]);
+
+        $update = $pdo->prepare('UPDATE beta_messages SET is_read = 1, read_at = COALESCE(read_at, NOW()) WHERE id = ?');
+        $update->execute([$messageId]);
+
+        $pdo->commit();
+
+        echo json_encode(['success' => true]);
+    } catch (Throwable $e) {
+        $pdo->rollBack();
+        echo json_encode(['success' => false, 'error' => 'Antwort konnte nicht gespeichert werden.']);
+    }
+
     exit;
 }
 
-$stmt = $pdo->prepare('SELECT COUNT(*) FROM beta_messages WHERE to_customer_email = ? AND is_read = 0');
-$stmt->execute([$customer['email']]);
-$initialUnreadCount = (int) $stmt->fetchColumn();
+if (!empty($_GET['ajax'])) {
+    $action = $_GET['ajax'];
+
+    if ($action === 'messages') {
+        $stats = computeMessageStats($pdo, $customer['email']);
+        $unread = fetchMessages($pdo, $customer['email'], 'unread', 50);
+        $read = fetchMessages($pdo, $customer['email'], 'read', 60);
+        $history = fetchMessages($pdo, $customer['email'], 'all', 50);
+
+        header('Content-Type: application/json');
+        echo json_encode([
+            'stats' => $stats,
+            'messages' => [
+                'unread' => $unread,
+                'read' => $read,
+            ],
+            'history' => $history,
+        ], JSON_UNESCAPED_UNICODE);
+        exit;
+    }
+
+    if ($action === 'profile') {
+        $profile = [
+            'name' => trim(($customer['first_name'] ?? '') . ' ' . ($customer['last_name'] ?? '')),
+            'email' => $customer['email'] ?? '',
+            'status' => $customer['status'] ?? 'active',
+            'registered_at' => $customer['created_at'] ?? null,
+            'last_login' => $customer['last_login'] ?? null,
+            'beta_role' => 'Lead Tester',
+            'session_started_at' => date('Y-m-d H:i:s', $_SESSION['session_start_time'] ?? time()),
+        ];
+
+        header('Content-Type: application/json');
+        echo json_encode($profile, JSON_UNESCAPED_UNICODE);
+        exit;
+    }
+
+    if ($action === 'activity') {
+        $sessions = fetchSessionHistory($pdo, (int) $customer['id'], 8);
+        $feed = fetchActivityFeed($pdo, $customer['email'], 12);
+        $stats = computeMessageStats($pdo, $customer['email']);
+
+        header('Content-Type: application/json');
+        echo json_encode([
+            'last_login' => $customer['last_login'] ?? null,
+            'session_started_at' => date('Y-m-d H:i:s', $_SESSION['session_start_time'] ?? time()),
+            'sessions' => $sessions,
+            'activity_feed' => $feed,
+            'responses_submitted' => $stats['responses_submitted'],
+            'unread_messages' => $stats['unread'],
+        ], JSON_UNESCAPED_UNICODE);
+        exit;
+    }
+
+    if ($action === 'beta_status') {
+        $betaStatus = computeBetaStatus($pdo, $customer['email']);
+
+        header('Content-Type: application/json');
+        echo json_encode($betaStatus, JSON_UNESCAPED_UNICODE);
+        exit;
+    }
+}
+
+$initialStats = computeMessageStats($pdo, $customer['email']);
+$initialUnreadCount = $initialStats['unread'];
 ?>
 <!DOCTYPE html>
 <html lang="de">
@@ -121,6 +446,7 @@ $initialUnreadCount = (int) $stmt->fetchColumn();
             --secondary: #52b3a4;
             --accent-green: #7cb342;
             --accent-teal: #26a69a;
+            --accent-purple: #6f42c1;
             --light-blue: #e3f2fd;
             --white: #ffffff;
             --gray-light: #f8f9fa;
@@ -180,7 +506,7 @@ $initialUnreadCount = (int) $stmt->fetchColumn();
         }
 
         .app-container {
-            max-width: 800px;
+            max-width: 900px;
             margin: 0 auto;
             min-height: 100vh;
             background: white;
@@ -217,8 +543,8 @@ $initialUnreadCount = (int) $stmt->fetchColumn();
         }
 
         .user-avatar {
-            width: 60px;
-            height: 60px;
+            width: 64px;
+            height: 64px;
             background: rgba(255, 255, 255, 0.2);
             border-radius: 50%;
             display: flex;
@@ -298,110 +624,6 @@ $initialUnreadCount = (int) $stmt->fetchColumn();
             padding: 1.5rem;
         }
 
-        .message-panel {
-            position: fixed;
-            top: 0;
-            right: -400px;
-            width: 400px;
-            height: 100vh;
-            background: white;
-            box-shadow: -4px 0 20px rgba(0,0,0,0.1);
-            z-index: 1001;
-            transition: right 0.3s ease;
-            display: flex;
-            flex-direction: column;
-        }
-
-        .message-panel.open {
-            right: 0;
-        }
-
-        .message-panel-header {
-            background: var(--primary);
-            color: white;
-            padding: 1rem;
-            display: flex;
-            justify-content: space-between;
-            align-items: center;
-        }
-
-        .close-panel {
-            background: none;
-            border: none;
-            color: white;
-            font-size: 1.5rem;
-            cursor: pointer;
-            padding: 0.25rem;
-        }
-
-        .message-list {
-            flex: 1;
-            overflow-y: auto;
-            padding: 1rem;
-        }
-
-        .message-item {
-            border-left: 4px solid var(--primary);
-            background: #f8f9fa;
-            padding: 1rem;
-            margin-bottom: 1rem;
-            border-radius: 0 8px 8px 0;
-            transition: all 0.3s ease;
-        }
-
-        .message-item.success { border-left-color: var(--success); }
-        .message-item.warning { border-left-color: var(--warning); }
-        .message-item.question { border-left-color: #6f42c1; }
-
-        .message-meta {
-            font-size: 0.875rem;
-            color: var(--gray-medium);
-            margin-bottom: 0.5rem;
-            display: flex;
-            justify-content: space-between;
-            align-items: center;
-        }
-
-        .message-text {
-            color: var(--gray-dark);
-            line-height: 1.6;
-            margin-bottom: 0.75rem;
-        }
-
-        .mark-read-btn {
-            background: var(--success);
-            color: white;
-            border: none;
-            padding: 0.5rem 1rem;
-            border-radius: 4px;
-            cursor: pointer;
-            font-size: 0.875rem;
-            transition: all 0.2s ease;
-        }
-
-        .mark-read-btn:hover {
-            background: #218838;
-            transform: translateY(-1px);
-        }
-
-        .overlay {
-            position: fixed;
-            top: 0;
-            left: 0;
-            width: 100%;
-            height: 100%;
-            background: rgba(0,0,0,0.5);
-            z-index: 1000;
-            opacity: 0;
-            visibility: hidden;
-            transition: all 0.3s ease;
-        }
-
-        .overlay.active {
-            opacity: 1;
-            visibility: visible;
-        }
-
         .welcome-section {
             text-align: center;
             margin-bottom: 2rem;
@@ -469,8 +691,426 @@ $initialUnreadCount = (int) $stmt->fetchColumn();
             color: var(--gray-medium);
         }
 
+        .message-panel {
+            position: fixed;
+            top: 0;
+            right: -470px;
+            width: 450px;
+            height: 100vh;
+            background: white;
+            box-shadow: -4px 0 20px rgba(0,0,0,0.1);
+            z-index: 1001;
+            transition: right 0.3s ease;
+            display: flex;
+            flex-direction: column;
+        }
+
+        .message-panel.open {
+            right: 0;
+        }
+
+        .message-panel.large {
+            width: 520px;
+        }
+
+        .message-panel.compact {
+            width: 380px;
+        }
+
+        .message-panel-header {
+            background: var(--primary);
+            color: white;
+            padding: 1rem;
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+        }
+
+        .close-panel {
+            background: none;
+            border: none;
+            color: white;
+            font-size: 1.5rem;
+            cursor: pointer;
+            padding: 0.25rem;
+        }
+
+        .panel-tabs {
+            display: flex;
+            gap: 0.5rem;
+            padding: 0.75rem 1rem;
+            background: #f0f4f8;
+            border-bottom: 1px solid #d9e2ec;
+        }
+
+        .panel-tab {
+            flex: 1;
+            background: transparent;
+            border: none;
+            padding: 0.5rem;
+            border-radius: 8px;
+            font-size: 0.85rem;
+            font-weight: 600;
+            color: var(--gray-medium);
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            gap: 0.35rem;
+            cursor: pointer;
+            transition: all 0.2s ease;
+        }
+
+        .panel-tab.active {
+            background: white;
+            color: var(--primary);
+            box-shadow: 0 2px 6px rgba(0,0,0,0.05);
+        }
+
+        .panel-content {
+            flex: 1;
+            overflow: hidden;
+            display: none;
+        }
+
+        .panel-content.active {
+            display: flex;
+            flex-direction: column;
+        }
+
+        .panel-scroll {
+            flex: 1;
+            overflow-y: auto;
+            padding: 1rem 1.25rem 1.25rem 1.25rem;
+        }
+        .message-subtabs {
+            display: flex;
+            gap: 0.5rem;
+            margin-bottom: 1rem;
+        }
+
+        .message-subtab {
+            flex: 1;
+            background: #f3f4f6;
+            border: none;
+            padding: 0.5rem;
+            border-radius: 8px;
+            font-size: 0.8rem;
+            font-weight: 600;
+            color: #6b7280;
+            cursor: pointer;
+            transition: all 0.2s ease;
+        }
+
+        .message-subtab.active {
+            background: var(--primary);
+            color: white;
+        }
+
+        .message-list {
+            display: flex;
+            flex-direction: column;
+            gap: 1rem;
+        }
+
+        .message-card {
+            border-left: 4px solid var(--primary);
+            background: #f8f9fa;
+            padding: 1rem;
+            border-radius: 0 12px 12px 0;
+            box-shadow: 0 2px 6px rgba(0,0,0,0.05);
+            display: flex;
+            flex-direction: column;
+            gap: 0.75rem;
+            transition: transform 0.2s ease;
+        }
+
+        .message-card:hover {
+            transform: translateY(-2px);
+        }
+
+        .message-card.success { border-left-color: var(--success); }
+        .message-card.warning { border-left-color: var(--warning); }
+        .message-card.question { border-left-color: var(--accent-purple); }
+
+        .message-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: flex-start;
+            gap: 0.5rem;
+        }
+
+        .message-header span {
+            font-size: 0.8rem;
+            color: var(--gray-medium);
+        }
+
+        .message-title {
+            font-weight: 600;
+            color: var(--gray-dark);
+            font-size: 0.95rem;
+            display: flex;
+            align-items: center;
+            gap: 0.35rem;
+        }
+
+        .message-body {
+            color: var(--gray-dark);
+            font-size: 0.9rem;
+            line-height: 1.6;
+            white-space: pre-wrap;
+        }
+
+        .message-actions {
+            display: flex;
+            gap: 0.5rem;
+            flex-wrap: wrap;
+        }
+
+        .btn {
+            border: none;
+            border-radius: 8px;
+            padding: 0.5rem 0.75rem;
+            font-size: 0.8rem;
+            font-weight: 600;
+            cursor: pointer;
+            transition: all 0.2s ease;
+            display: inline-flex;
+            align-items: center;
+            gap: 0.35rem;
+        }
+
+        .btn-primary { background: var(--primary); color: white; }
+        .btn-primary:hover { background: #2b6cb0; }
+
+        .btn-success { background: var(--success); color: white; }
+        .btn-success:hover { background: #1e7e34; }
+
+        .btn-danger { background: var(--danger); color: white; }
+        .btn-danger:hover { background: #b21f2d; }
+
+        .btn-outline {
+            background: transparent;
+            border: 1px solid var(--gray-medium);
+            color: var(--gray-medium);
+        }
+
+        .btn-outline:hover {
+            color: var(--gray-dark);
+            border-color: var(--gray-dark);
+        }
+
+        .response-status {
+            font-size: 0.8rem;
+            font-weight: 600;
+            color: var(--gray-medium);
+            display: flex;
+            align-items: center;
+            gap: 0.35rem;
+        }
+
+        .stats-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+            gap: 0.75rem;
+            margin-bottom: 1rem;
+        }
+
+        .stat-card {
+            background: white;
+            border-radius: 12px;
+            padding: 0.75rem;
+            box-shadow: 0 2px 6px rgba(0,0,0,0.05);
+            border: 1px solid #e5e7eb;
+        }
+
+        .stat-card h4 {
+            font-size: 0.85rem;
+            color: var(--gray-medium);
+            margin-bottom: 0.25rem;
+        }
+
+        .stat-card strong {
+            font-size: 1.1rem;
+            color: var(--gray-dark);
+        }
+
+        .history-list {
+            margin-top: 1rem;
+        }
+
+        .history-item {
+            border-left: 3px solid var(--primary);
+            padding: 0.75rem 0.75rem 0.75rem 1rem;
+            margin-bottom: 0.75rem;
+            background: #f9fafb;
+            border-radius: 0 10px 10px 0;
+        }
+
+        .history-item strong {
+            display: block;
+            font-size: 0.9rem;
+            margin-bottom: 0.25rem;
+        }
+
+        .profile-section,
+        .activity-section,
+        .beta-status-section {
+            display: flex;
+            flex-direction: column;
+            gap: 1rem;
+        }
+
+        .info-card {
+            background: white;
+            border-radius: 12px;
+            padding: 1rem;
+            box-shadow: 0 2px 6px rgba(0,0,0,0.05);
+            border: 1px solid #e5e7eb;
+        }
+
+        .info-card h3 {
+            margin-bottom: 0.5rem;
+            font-size: 1rem;
+            display: flex;
+            align-items: center;
+            gap: 0.4rem;
+        }
+
+        .info-list {
+            list-style: none;
+            display: flex;
+            flex-direction: column;
+            gap: 0.5rem;
+            font-size: 0.9rem;
+        }
+
+        .timeline {
+            border-left: 2px solid #d1d5db;
+            padding-left: 1rem;
+            display: flex;
+            flex-direction: column;
+            gap: 0.75rem;
+        }
+
+        .timeline-item {
+            position: relative;
+            background: #f9fafb;
+            border-radius: 10px;
+            padding: 0.75rem;
+            box-shadow: 0 1px 4px rgba(0,0,0,0.05);
+        }
+
+        .timeline-item::before {
+            content: '';
+            position: absolute;
+            left: -1.2rem;
+            top: 0.8rem;
+            width: 0.75rem;
+            height: 0.75rem;
+            background: var(--primary);
+            border-radius: 50%;
+        }
+
+        .progress-bar {
+            width: 100%;
+            height: 10px;
+            background: #e5e7eb;
+            border-radius: 6px;
+            overflow: hidden;
+            margin-top: 0.5rem;
+        }
+
+        .progress-bar span {
+            display: block;
+            height: 100%;
+            background: linear-gradient(90deg, var(--primary), var(--secondary));
+        }
+
+        .settings-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+            gap: 0.75rem;
+        }
+
+        .setting-card {
+            background: #f8fafc;
+            border-radius: 10px;
+            padding: 0.75rem;
+            border: 1px solid #e2e8f0;
+            display: flex;
+            flex-direction: column;
+            gap: 0.5rem;
+            font-size: 0.85rem;
+        }
+
+        .setting-card label {
+            font-weight: 600;
+            color: var(--gray-dark);
+        }
+
+        .overlay {
+            position: fixed;
+            top: 0;
+            left: 0;
+            width: 100%;
+            height: 100%;
+            background: rgba(0,0,0,0.5);
+            z-index: 1000;
+            opacity: 0;
+            visibility: hidden;
+            transition: all 0.3s ease;
+        }
+
+        .overlay.active {
+            opacity: 1;
+            visibility: visible;
+        }
+
+        .panel-theme-dark {
+            background: #1f2937;
+            color: #f9fafb;
+        }
+
+        .panel-theme-dark .panel-tabs {
+            background: #111827;
+        }
+
+        .panel-theme-dark .panel-tab {
+            color: #d1d5db;
+        }
+
+        .panel-theme-dark .panel-tab.active {
+            background: #374151;
+            color: #f9fafb;
+        }
+
+        .panel-theme-dark .panel-scroll {
+            background: #111827;
+        }
+
+        .panel-theme-dark .message-card,
+        .panel-theme-dark .info-card,
+        .panel-theme-dark .stat-card,
+        .panel-theme-dark .timeline-item,
+        .panel-theme-dark .setting-card {
+            background: #1f2937;
+            color: #f9fafb;
+            border-color: #374151;
+        }
+
+        .panel-theme-dark .message-subtab {
+            background: #374151;
+            color: #d1d5db;
+        }
+
+        .panel-theme-dark .message-subtab.active {
+            background: var(--accent-purple);
+        }
+
         @media (max-width: 768px) {
-            .message-panel {
+            .message-panel,
+            .message-panel.large,
+            .message-panel.compact {
                 width: 100%;
                 right: -100%;
             }
@@ -484,8 +1124,8 @@ $initialUnreadCount = (int) $stmt->fetchColumn();
             }
 
             .user-avatar {
-                width: 50px;
-                height: 50px;
+                width: 54px;
+                height: 54px;
                 font-size: 1.5rem;
             }
 
@@ -505,7 +1145,7 @@ $initialUnreadCount = (int) $stmt->fetchColumn();
     <div class="app-container">
         <div class="app-header">
             <div class="header-content">
-                <div class="user-avatar" onclick="toggleMessagePanel()">
+                <div class="user-avatar" onclick="toggleMessagePanel()" title="Beta Panel öffnen">
                     👤
                     <div class="message-badge" id="messageBadge" style="display: <?= $initialUnreadCount > 0 ? 'flex' : 'none' ?>;">
                         <?= $initialUnreadCount > 99 ? '99+' : $initialUnreadCount; ?>
@@ -523,60 +1163,182 @@ $initialUnreadCount = (int) $stmt->fetchColumn();
 
         <div class="app-content">
             <div class="welcome-section">
-                <h2>Willkommen in der Beta-Umgebung!</h2>
-                <p>Hier testest du neue Features bevor sie für alle verfügbar sind. Klicke auf dein Profilbild um Nachrichten zu sehen.</p>
+                <h2>Willkommen im neuen Beta-Dashboard</h2>
+                <p>Teste brandneue Funktionen, gib direktes Feedback und verfolge deinen Fortschritt.</p>
             </div>
 
             <div class="actions-grid">
-                <a href="../customer/booking.php" class="action-card">
-                    <div class="action-icon">📅</div>
+                <div class="action-card" onclick="toggleMessagePanel()" role="button">
+                    <div class="action-icon">💬</div>
                     <div class="action-content">
-                        <h3>Termine buchen</h3>
-                        <p>Verfügbare Termine finden und buchen</p>
+                        <h3>Nachrichten & Feedback</h3>
+                        <p>Sofortige Updates vom Admin-Team mit Ja/Nein Antworten.</p>
                     </div>
-                </a>
-
-                <a href="../customer/appointments.php" class="action-card">
-                    <div class="action-icon">📋</div>
+                </div>
+                <div class="action-card" onclick="openPanelTab('profile')" role="button">
+                    <div class="action-icon">👤</div>
                     <div class="action-content">
-                        <h3>Meine Termine</h3>
-                        <p>Gebuchte Termine verwalten</p>
+                        <h3>Profil & Einstellungen</h3>
+                        <p>Kontaktdaten, Beta-Rolle und Panel-Anpassungen einsehen.</p>
                     </div>
-                </a>
-
-                <a href="../customer/index.php" class="action-card">
-                    <div class="action-icon">🏠</div>
+                </div>
+                <div class="action-card" onclick="openPanelTab('activity')" role="button">
+                    <div class="action-icon">📈</div>
                     <div class="action-content">
-                        <h3>Normal Dashboard</h3>
-                        <p>Zur Standard Customer App wechseln</p>
+                        <h3>Aktivitäts-Tracking</h3>
+                        <p>Letzte Sessions, Tests und Antworten im Überblick.</p>
                     </div>
-                </a>
-
-                <div class="action-card" style="border: 2px dashed #667eea; opacity: 0.7; cursor: default;">
-                    <div class="action-icon" style="background: #667eea;">🚀</div>
+                </div>
+                <div class="action-card" onclick="openPanelTab('beta-status')" role="button">
+                    <div class="action-icon">🚀</div>
                     <div class="action-content">
-                        <h3>Mehr Features Coming Soon</h3>
-                        <p>Push Notifications, Dark Mode, etc.</p>
+                        <h3>Beta-Status</h3>
+                        <p>Fortschritt, Engagement und getestete Features anzeigen.</p>
                     </div>
                 </div>
             </div>
         </div>
     </div>
 
-    <div class="overlay" id="overlay" onclick="closeMessagePanel()"></div>
     <div class="message-panel" id="messagePanel">
         <div class="message-panel-header">
-            <h3>📨 Beta Nachrichten</h3>
-            <button class="close-panel" type="button" onclick="closeMessagePanel()">×</button>
+            <div>
+                <strong>Beta Control Center</strong>
+                <div style="font-size:0.8rem;opacity:0.85;">Kommunikation • Feedback • Fortschritt</div>
+            </div>
+            <button class="close-panel" type="button" onclick="closeMessagePanel()" aria-label="Panel schließen">×</button>
         </div>
-        <div class="message-list" id="messageList"></div>
+
+        <div class="panel-tabs">
+            <button class="panel-tab active" data-tab="messages">💬 Nachrichten</button>
+            <button class="panel-tab" data-tab="profile">👤 Profil</button>
+            <button class="panel-tab" data-tab="activity">📊 Aktivität</button>
+            <button class="panel-tab" data-tab="beta-status">🚀 Beta-Status</button>
+        </div>
+
+        <div class="panel-content active" data-content="messages">
+            <div class="panel-scroll">
+                <div class="stats-grid" id="messageStats"></div>
+
+                <div class="message-subtabs">
+                    <button class="message-subtab active" data-subtab="new">📬 Neu</button>
+                    <button class="message-subtab" data-subtab="read">📁 Gelesen</button>
+                </div>
+
+                <div class="message-list" id="newMessages"></div>
+                <div class="message-list" id="readMessages" style="display:none;"></div>
+
+                <div class="info-card" id="messageHistoryCard" style="margin-top:1.5rem;">
+                    <h3>🗂️ Nachrichten- und Response-Verlauf</h3>
+                    <div class="history-list" id="messageHistory"></div>
+                </div>
+            </div>
+        </div>
+
+        <div class="panel-content" data-content="profile">
+            <div class="panel-scroll">
+                <div class="profile-section" id="profileContent"></div>
+            </div>
+        </div>
+
+        <div class="panel-content" data-content="activity">
+            <div class="panel-scroll">
+                <div class="activity-section" id="activityContent"></div>
+            </div>
+        </div>
+
+        <div class="panel-content" data-content="beta-status">
+            <div class="panel-scroll">
+                <div class="beta-status-section" id="betaStatusContent"></div>
+            </div>
+        </div>
     </div>
 
+    <div class="overlay" id="overlay" onclick="closeMessagePanel()"></div>
     <script>
         const messagePanel = document.getElementById('messagePanel');
         const overlay = document.getElementById('overlay');
         const messageBadge = document.getElementById('messageBadge');
-        const messageList = document.getElementById('messageList');
+        const messageStatsContainer = document.getElementById('messageStats');
+        const newMessagesContainer = document.getElementById('newMessages');
+        const readMessagesContainer = document.getElementById('readMessages');
+        const messageHistoryContainer = document.getElementById('messageHistory');
+        const profileContent = document.getElementById('profileContent');
+        const activityContent = document.getElementById('activityContent');
+        const betaStatusContent = document.getElementById('betaStatusContent');
+        const panelTabs = Array.from(document.querySelectorAll('.panel-tab'));
+        const panelSections = Array.from(document.querySelectorAll('.panel-content'));
+        const messageSubtabs = Array.from(document.querySelectorAll('.message-subtab'));
+
+        let messageDataCache = null;
+        let profileDataCache = null;
+        let activityDataCache = null;
+        let betaStatusCache = null;
+
+        const settingsKey = 'betaPanelSettings';
+        const settingsDefaults = {
+            notifications: true,
+            panelSize: 'standard',
+            theme: 'light',
+        };
+
+        function loadSettings() {
+            try {
+                const stored = localStorage.getItem(settingsKey);
+                if (!stored) {
+                    return { ...settingsDefaults };
+                }
+                const parsed = JSON.parse(stored);
+                return { ...settingsDefaults, ...parsed };
+            } catch (error) {
+                console.warn('Settings konnten nicht geladen werden.', error);
+                return { ...settingsDefaults };
+            }
+        }
+
+        let panelSettings = loadSettings();
+
+        function saveSettings() {
+            try {
+                localStorage.setItem(settingsKey, JSON.stringify(panelSettings));
+            } catch (error) {
+                console.warn('Settings konnten nicht gespeichert werden.', error);
+            }
+        }
+
+        function applyPanelPreferences() {
+            messagePanel.classList.remove('large', 'compact', 'panel-theme-dark');
+
+            if (panelSettings.panelSize === 'large') {
+                messagePanel.classList.add('large');
+            } else if (panelSettings.panelSize === 'compact') {
+                messagePanel.classList.add('compact');
+            }
+
+            if (panelSettings.theme === 'dark') {
+                messagePanel.classList.add('panel-theme-dark');
+            }
+        }
+
+        function escapeHtml(str) {
+            return String(str)
+                .replace(/&/g, '&amp;')
+                .replace(/</g, '&lt;')
+                .replace(/>/g, '&gt;')
+                .replace(/"/g, '&quot;')
+                .replace(/'/g, '&#039;');
+        }
+
+        function formatDate(value) {
+            if (!value) {
+                return '—';
+            }
+            const date = new Date(value.replace(' ', 'T'));
+            if (Number.isNaN(date.getTime())) {
+                return escapeHtml(value);
+            }
+            return date.toLocaleString('de-DE');
+        }
 
         function toggleMessagePanel() {
             if (messagePanel.classList.contains('open')) {
@@ -589,6 +1351,7 @@ $initialUnreadCount = (int) $stmt->fetchColumn();
         function openMessagePanel() {
             messagePanel.classList.add('open');
             overlay.classList.add('active');
+            applyPanelPreferences();
             loadMessages();
         }
 
@@ -597,108 +1360,535 @@ $initialUnreadCount = (int) $stmt->fetchColumn();
             overlay.classList.remove('active');
         }
 
-        function loadMessages() {
-            fetch('?ajax=1', { credentials: 'same-origin' })
-                .then((response) => response.json())
-                .then((data) => {
-                    updateMessageBadge(data.unread_count);
-                    renderMessages(Array.isArray(data.messages) ? data.messages : []);
-                })
-                .catch((error) => {
-                    console.error('Error loading messages:', error);
-                });
-        }
-
-        function renderMessages(messages) {
-            if (!messages.length) {
-                messageList.innerHTML = `
-                    <div style="text-align:center;padding:2rem;color:#6b7280;">
-                        <p>📭 Keine ungelesenen Nachrichten</p>
-                        <p style="font-size:0.875rem;margin-top:0.5rem;">Der Admin kann dir hier Updates senden</p>
-                    </div>
-                `;
-                return;
+        function openPanelTab(tabName) {
+            if (!messagePanel.classList.contains('open')) {
+                openMessagePanel();
             }
-
-            const icons = {
-                info: 'ℹ️',
-                success: '✅',
-                warning: '⚠️',
-                question: '❓'
-            };
-
-            messageList.innerHTML = messages.map((msg) => {
-                const type = msg.message_type || 'info';
-                const icon = icons[type] || 'ℹ️';
-                const createdAt = new Date(msg.created_at).toLocaleString('de-DE');
-                const text = String(msg.message_text || '')
-                    .replace(/\n/g, '<br>');
-
-                return `
-                    <div class="message-item ${type}">
-                        <div class="message-meta">
-                            <span>${icon} ${type.charAt(0).toUpperCase() + type.slice(1)}</span>
-                            <span>${createdAt}</span>
-                        </div>
-                        <div class="message-text">${text}</div>
-                        <button class="mark-read-btn" type="button" onclick="markAsRead(${Number(msg.id)})">
-                            ✓ Als gelesen markieren
-                        </button>
-                    </div>
-                `;
-            }).join('');
+            activateMainTab(tabName);
         }
 
-        function markAsRead(messageId) {
-            if (!messageId) {
-                return;
+        function activateMainTab(tabName) {
+            panelTabs.forEach((button) => {
+                const isActive = button.dataset.tab === tabName;
+                button.classList.toggle('active', isActive);
+            });
+
+            panelSections.forEach((section) => {
+                const isActive = section.dataset.content === tabName;
+                section.classList.toggle('active', isActive);
+            });
+
+            if (tabName === 'messages') {
+                loadMessages();
+            } else if (tabName === 'profile') {
+                loadProfile();
+            } else if (tabName === 'activity') {
+                loadActivity();
+            } else if (tabName === 'beta-status') {
+                loadBetaStatus();
             }
-
-            fetch('', {
-                method: 'POST',
-                headers: {
-                    'Content-Type': 'application/x-www-form-urlencoded'
-                },
-                body: `mark_read=1&message_id=${encodeURIComponent(messageId)}`,
-                credentials: 'same-origin'
-            })
-                .then((response) => response.json())
-                .then((data) => {
-                    if (data && data.success) {
-                        loadMessages();
-                    }
-                })
-                .catch((error) => {
-                    console.error('Error marking message as read:', error);
-                });
         }
 
+        panelTabs.forEach((button) => {
+            button.addEventListener('click', () => {
+                activateMainTab(button.dataset.tab);
+            });
+        });
+
+        messageSubtabs.forEach((button) => {
+            button.addEventListener('click', () => {
+                const subtab = button.dataset.subtab;
+                messageSubtabs.forEach((btn) => btn.classList.toggle('active', btn === button));
+                if (subtab === 'new') {
+                    newMessagesContainer.style.display = '';
+                    readMessagesContainer.style.display = 'none';
+                } else {
+                    newMessagesContainer.style.display = 'none';
+                    readMessagesContainer.style.display = '';
+                }
+            });
+        });
         function updateMessageBadge(count) {
-            const parsed = Number(count) || 0;
-
-            if (parsed > 0) {
+            const total = Number(count) || 0;
+            if (total > 0) {
                 messageBadge.style.display = 'flex';
-                messageBadge.textContent = parsed > 99 ? '99+' : parsed;
+                messageBadge.textContent = total > 99 ? '99+' : total;
             } else {
                 messageBadge.style.display = 'none';
             }
         }
 
-        setInterval(() => {
-            fetch('?ajax=1', { credentials: 'same-origin' })
-                .then((response) => response.json())
-                .then((data) => {
-                    updateMessageBadge(data.unread_count);
-
-                    if (messagePanel.classList.contains('open')) {
-                        renderMessages(Array.isArray(data.messages) ? data.messages : []);
+        function fetchJson(url, options = {}) {
+            return fetch(url, { credentials: 'same-origin', ...options })
+                .then((response) => {
+                    if (!response.ok) {
+                        throw new Error('Network response was not ok');
                     }
+                    return response.json();
+                });
+        }
+
+        function renderStats(stats) {
+            if (!stats) {
+                messageStatsContainer.innerHTML = '';
+                return;
+            }
+
+            const responseTotal = stats.response_breakdown.yes + stats.response_breakdown.no;
+            const yesPercent = responseTotal > 0 ? Math.round((stats.response_breakdown.yes / responseTotal) * 100) : 0;
+            const noPercent = responseTotal > 0 ? Math.round((stats.response_breakdown.no / responseTotal) * 100) : 0;
+
+            messageStatsContainer.innerHTML = `
+                <div class="stat-card">
+                    <h4>Gesamt</h4>
+                    <strong>${stats.total}</strong>
+                </div>
+                <div class="stat-card">
+                    <h4>Ungelesen</h4>
+                    <strong>${stats.unread}</strong>
+                </div>
+                <div class="stat-card">
+                    <h4>Antwort erforderlich</h4>
+                    <strong>${stats.needs_response}</strong>
+                </div>
+                <div class="stat-card">
+                    <h4>Antworten</h4>
+                    <strong>${stats.responses_submitted}</strong>
+                    <div style="font-size:0.75rem;color:var(--gray-medium);margin-top:0.25rem;">
+                        ✅ ${yesPercent}% • ❌ ${noPercent}%
+                    </div>
+                </div>
+            `;
+        }
+
+        function buildMessageCard(message, isUnread) {
+            const typeIcons = { info: 'ℹ️', success: '✅', warning: '⚠️', question: '❓' };
+            const icon = typeIcons[message.message_type] || 'ℹ️';
+            const response = message.user_response;
+            const responseStatus = response ? (response === 'yes' ? '✅ Ja' : '❌ Nein') : 'Keine Antwort';
+            const buttons = [];
+
+            if (message.expects_response && !response) {
+                buttons.push(`
+                    <button class="btn btn-success" data-action="respond" data-message-id="${message.id}" data-response="yes">
+                        ✅ Ja
+                    </button>
+                `);
+                buttons.push(`
+                    <button class="btn btn-danger" data-action="respond" data-message-id="${message.id}" data-response="no">
+                        ❌ Nein
+                    </button>
+                `);
+            }
+
+            if (isUnread && !message.expects_response) {
+                buttons.push(`
+                    <button class="btn btn-primary" data-action="mark-read" data-message-id="${message.id}">
+                        ✓ Als gelesen markieren
+                    </button>
+                `);
+            }
+
+            const questionBlock = message.expects_response ? `
+                <div style="background:#edf2ff;padding:0.75rem;border-radius:8px;border:1px solid #dbe4ff;">
+                    <div style="font-weight:600;margin-bottom:0.25rem;">${icon} Admin-Frage:</div>
+                    <div style="font-size:0.85rem;margin-bottom:0.75rem;">${escapeHtml(message.response_question || 'Bitte gib uns Feedback.')}</div>
+                    ${response ? `<div class="response-status">${responseStatus} • ${formatDate(message.responded_at)}</div>` : ''}
+                </div>
+            ` : '';
+
+            return `
+                <div class="message-card ${escapeHtml(message.message_type)}">
+                    <div class="message-header">
+                        <div class="message-title">${icon} ${escapeHtml(message.message_type.charAt(0).toUpperCase() + message.message_type.slice(1))}</div>
+                        <span>${formatDate(message.created_at)}</span>
+                    </div>
+                    <div class="message-body">${escapeHtml(message.message_text)}</div>
+                    ${questionBlock}
+                    ${buttons.length ? `<div class="message-actions">${buttons.join('')}</div>` : ''}
+                    ${response && !message.expects_response ? `<div class="response-status">${responseStatus} • ${formatDate(message.responded_at)}</div>` : ''}
+                    ${!isUnread && message.read_at ? `<div class="response-status">📁 Gelesen am ${formatDate(message.read_at)}</div>` : ''}
+                </div>
+            `;
+        }
+
+        function renderMessageHistory(history) {
+            if (!history || history.length === 0) {
+                messageHistoryContainer.innerHTML = '<p style="font-size:0.85rem;color:#6b7280;">Noch keine Historie vorhanden.</p>';
+                return;
+            }
+
+            const items = history.slice(0, 10).map((item) => {
+                const status = item.expects_response
+                    ? (item.user_response ? `Antwort: ${item.user_response === 'yes' ? 'Ja' : 'Nein'}` : 'Wartet auf Antwort')
+                    : (item.is_read ? 'Gelesen' : 'Offen');
+                const readInfo = item.read_at ? ` • gelesen ${formatDate(item.read_at)}` : '';
+                const responseInfo = item.responded_at ? ` • Antwort ${formatDate(item.responded_at)}` : '';
+                return `
+                    <div class="history-item">
+                        <strong>${escapeHtml(item.message_text.substring(0, 80))}${item.message_text.length > 80 ? '…' : ''}</strong>
+                        <div style="font-size:0.8rem;color:#6b7280;">
+                            ${formatDate(item.created_at)} • ${escapeHtml(status)}${readInfo}${responseInfo}
+                        </div>
+                    </div>
+                `;
+            });
+
+            messageHistoryContainer.innerHTML = items.join('');
+        }
+
+        function renderMessageLists(data) {
+            const unreadMessages = Array.isArray(data.messages?.unread) ? data.messages.unread : [];
+            const readMessages = Array.isArray(data.messages?.read) ? data.messages.read : [];
+
+            if (unreadMessages.length === 0) {
+                newMessagesContainer.innerHTML = `
+                    <div style="text-align:center;padding:2rem;color:#6b7280;font-size:0.9rem;">
+                        <p>📭 Keine neuen Nachrichten</p>
+                        <p style="font-size:0.8rem;margin-top:0.5rem;">Wir benachrichtigen dich, sobald etwas Neues da ist.</p>
+                    </div>
+                `;
+            } else {
+                newMessagesContainer.innerHTML = unreadMessages.map((message) => buildMessageCard(message, true)).join('');
+            }
+
+            if (readMessages.length === 0) {
+                readMessagesContainer.innerHTML = `
+                    <div style="text-align:center;padding:2rem;color:#6b7280;font-size:0.9rem;">
+                        <p>📂 Hier landen gelesene Nachrichten.</p>
+                        <p style="font-size:0.8rem;margin-top:0.5rem;">Antworten und Zeitstempel bleiben erhalten.</p>
+                    </div>
+                `;
+            } else {
+                readMessagesContainer.innerHTML = readMessages.map((message) => buildMessageCard(message, false)).join('');
+            }
+
+            renderMessageHistory(data.history || []);
+        }
+
+        function loadMessages() {
+            fetchJson('?ajax=messages')
+                .then((data) => {
+                    messageDataCache = data;
+                    updateMessageBadge(data?.stats?.unread || 0);
+                    renderStats(data.stats);
+                    renderMessageLists(data);
                 })
                 .catch((error) => {
-                    console.error('Auto-refresh error:', error);
+                    console.error('Nachrichten konnten nicht geladen werden:', error);
                 });
+        }
+        document.addEventListener('click', (event) => {
+            const target = event.target.closest('[data-action]');
+            if (!target) {
+                return;
+            }
+
+            const messageId = target.dataset.messageId;
+            if (!messageId) {
+                return;
+            }
+
+            if (target.dataset.action === 'mark-read') {
+                event.preventDefault();
+                markMessageAsRead(messageId);
+            } else if (target.dataset.action === 'respond') {
+                event.preventDefault();
+                const responseValue = target.dataset.response;
+                respondToMessage(messageId, responseValue);
+            }
+        });
+
+        function markMessageAsRead(messageId) {
+            const body = new URLSearchParams({ mark_read: '1', message_id: messageId });
+            fetchJson('', { method: 'POST', body })
+                .then(() => {
+                    loadMessages();
+                })
+                .catch((error) => {
+                    console.error('Nachricht konnte nicht markiert werden:', error);
+                });
+        }
+
+        function respondToMessage(messageId, responseType) {
+            const body = new URLSearchParams({
+                respond_to_message: '1',
+                message_id: messageId,
+                response_type: responseType,
+            });
+
+            fetchJson('', { method: 'POST', body })
+                .then((result) => {
+                    if (!result.success) {
+                        throw new Error(result.error || 'Antwort nicht gespeichert');
+                    }
+                    loadMessages();
+                    betaStatusCache = null;
+                    activityDataCache = null;
+                })
+                .catch((error) => {
+                    console.error('Antwort konnte nicht gesendet werden:', error);
+                });
+        }
+        function renderProfile(profile) {
+            profileContent.innerHTML = `
+                <div class="info-card">
+                    <h3>👤 Profilübersicht</h3>
+                    <ul class="info-list">
+                        <li><strong>Name:</strong> ${escapeHtml(profile.name || '—')}</li>
+                        <li><strong>Email:</strong> ${escapeHtml(profile.email || '—')}</li>
+                        <li><strong>Status:</strong> ${escapeHtml(profile.status || '—')}</li>
+                        <li><strong>Beta-Rolle:</strong> ${escapeHtml(profile.beta_role || '—')}</li>
+                        <li><strong>Registriert:</strong> ${formatDate(profile.registered_at)}</li>
+                        <li><strong>Letzter Login:</strong> ${formatDate(profile.last_login)}</li>
+                        <li><strong>Aktive Session seit:</strong> ${formatDate(profile.session_started_at)}</li>
+                    </ul>
+                </div>
+                <div class="info-card">
+                    <h3>⚙️ Panel Einstellungen</h3>
+                    <div class="settings-grid">
+                        <div class="setting-card">
+                            <label for="settingNotifications">Benachrichtigungen</label>
+                            <p>Badge-Updates und Auto-Refresh aktivieren.</p>
+                            <input type="checkbox" id="settingNotifications">
+                        </div>
+                        <div class="setting-card">
+                            <label for="settingPanelSize">Panel-Größe</label>
+                            <select id="settingPanelSize">
+                                <option value="standard">Standard</option>
+                                <option value="large">Groß</option>
+                                <option value="compact">Kompakt</option>
+                            </select>
+                        </div>
+                        <div class="setting-card">
+                            <label for="settingTheme">Panel-Theme</label>
+                            <select id="settingTheme">
+                                <option value="light">Hell</option>
+                                <option value="dark">Dunkel</option>
+                            </select>
+                        </div>
+                    </div>
+                </div>
+            `;
+        }
+
+        function setupSettingsControls() {
+            const notificationToggle = document.getElementById('settingNotifications');
+            const panelSizeSelect = document.getElementById('settingPanelSize');
+            const themeSelect = document.getElementById('settingTheme');
+
+            if (notificationToggle) {
+                notificationToggle.checked = !!panelSettings.notifications;
+                notificationToggle.addEventListener('change', () => {
+                    panelSettings.notifications = notificationToggle.checked;
+                    saveSettings();
+                });
+            }
+
+            if (panelSizeSelect) {
+                panelSizeSelect.value = panelSettings.panelSize;
+                panelSizeSelect.addEventListener('change', () => {
+                    panelSettings.panelSize = panelSizeSelect.value;
+                    applyPanelPreferences();
+                    saveSettings();
+                });
+            }
+
+            if (themeSelect) {
+                themeSelect.value = panelSettings.theme;
+                themeSelect.addEventListener('change', () => {
+                    panelSettings.theme = themeSelect.value;
+                    applyPanelPreferences();
+                    saveSettings();
+                });
+            }
+        }
+
+        function loadProfile() {
+            if (profileDataCache) {
+                renderProfile(profileDataCache);
+                setupSettingsControls();
+                applyPanelPreferences();
+                return;
+            }
+
+            fetchJson('?ajax=profile')
+                .then((data) => {
+                    profileDataCache = data;
+                    renderProfile(data);
+                    setupSettingsControls();
+                    applyPanelPreferences();
+                })
+                .catch((error) => {
+                    console.error('Profil konnte nicht geladen werden:', error);
+                });
+        }
+        function renderActivity(data) {
+            const sessions = Array.isArray(data.sessions) ? data.sessions : [];
+            const feed = Array.isArray(data.activity_feed) ? data.activity_feed : [];
+
+            const sessionTimeline = sessions.length
+                ? `<div class="timeline">${sessions.map((session) => `
+                        <div class="timeline-item">
+                            <div style="font-weight:600;">🔐 Session gestartet</div>
+                            <div style="font-size:0.8rem;color:#9ca3af;">${formatDate(session.created_at)} • endet ${formatDate(session.expires_at)}</div>
+                        </div>
+                    `).join('')}</div>`
+                : '<p style="font-size:0.85rem;color:#6b7280;">Noch keine Sessions aufgezeichnet.</p>';
+
+            const feedTimeline = feed.length
+                ? `<div class="timeline">${feed.map((item) => {
+                        const iconMap = { message: '💡', read: '📖', response: '✅' };
+                        const icon = iconMap[item.type] || '🧪';
+                        return `
+                            <div class="timeline-item">
+                                <div style="font-weight:600;">${icon} ${escapeHtml(item.title || '')}</div>
+                                <div style="font-size:0.85rem;margin:0.35rem 0;">${escapeHtml(item.details || '')}</div>
+                                <div style="font-size:0.75rem;color:#9ca3af;">${formatDate(item.timestamp)}</div>
+                            </div>
+                        `;
+                    }).join('')}</div>`
+                : '<p style="font-size:0.85rem;color:#6b7280;">Noch keine Aktivität registriert.</p>';
+
+            activityContent.innerHTML = `
+                <div class="info-card">
+                    <h3>📊 Aktivitätsübersicht</h3>
+                    <ul class="info-list">
+                        <li><strong>Letzter Login:</strong> ${formatDate(data.last_login)}</li>
+                        <li><strong>Aktive Session:</strong> ${formatDate(data.session_started_at)}</li>
+                        <li><strong>Ungelesene Nachrichten:</strong> ${data.unread_messages ?? 0}</li>
+                        <li><strong>Gesendete Antworten:</strong> ${data.responses_submitted ?? 0}</li>
+                    </ul>
+                </div>
+                <div class="info-card">
+                    <h3>🕒 Session-Historie</h3>
+                    ${sessionTimeline}
+                </div>
+                <div class="info-card">
+                    <h3>🧪 Testing-Aktivität</h3>
+                    ${feedTimeline}
+                </div>
+            `;
+        }
+
+        function loadActivity() {
+            if (activityDataCache) {
+                renderActivity(activityDataCache);
+                return;
+            }
+
+            fetchJson('?ajax=activity')
+                .then((data) => {
+                    activityDataCache = data;
+                    renderActivity(data);
+                })
+                .catch((error) => {
+                    console.error('Aktivität konnte nicht geladen werden:', error);
+                });
+        }
+        function renderBetaStatus(data) {
+            const stats = data.stats || {};
+            const progress = Number(data.progress || 0);
+            const engagementRate = Number(data.engagement_rate || 0).toFixed(1);
+            const streak = Number(data.testing_streak || 0);
+            const featureUsage = Array.isArray(data.feature_usage) ? data.feature_usage : [];
+            const recentFeatures = Array.isArray(data.recent_features) ? data.recent_features : [];
+
+            const usageList = featureUsage.length
+                ? `<ul class="info-list">${featureUsage.map((item) => `
+                        <li>${escapeHtml(item.label || 'Feature')} • ${item.count} Interaktionen</li>
+                    `).join('')}</ul>`
+                : '<p style="font-size:0.85rem;color:#6b7280;">Noch keine Feature-Interaktionen aufgezeichnet.</p>';
+
+            const recentTimeline = recentFeatures.length
+                ? `<div class="timeline">${recentFeatures.map((feature) => {
+                        const statusBadge = feature.status || '';
+                        const responseInfo = feature.response ? `Antwort: ${feature.response === 'yes' ? 'Ja' : 'Nein'}` : 'Keine Antwort';
+                        return `
+                            <div class="timeline-item">
+                                <div style="font-weight:600;">🚀 ${escapeHtml(feature.title || '')}</div>
+                                <div style="font-size:0.85rem;margin:0.35rem 0;">${escapeHtml(statusBadge)} • ${escapeHtml(responseInfo)}</div>
+                                <div style="font-size:0.75rem;color:#9ca3af;">${formatDate(feature.created_at)}${feature.read_at ? ' • gelesen ' + formatDate(feature.read_at) : ''}</div>
+                            </div>
+                        `;
+                    }).join('')}</div>`
+                : '<p style="font-size:0.85rem;color:#6b7280;">Noch keine getesteten Features verfügbar.</p>';
+
+            betaStatusContent.innerHTML = `
+                <div class="info-card">
+                    <h3>🚀 Beta-Fortschritt</h3>
+                    <div style="display:flex;justify-content:space-between;align-items:center;">
+                        <div style="font-size:2rem;font-weight:700;color:var(--primary);">${progress}%</div>
+                        <div style="text-align:right;font-size:0.85rem;color:#6b7280;">
+                            Engagement: ${engagementRate}%<br>
+                            Testing-Streak: ${streak} ${streak === 1 ? 'Tag' : 'Tage'}
+                        </div>
+                    </div>
+                    <div class="progress-bar" aria-hidden="true"><span style="width:${Math.max(0, Math.min(progress, 100))}%;"></span></div>
+                </div>
+                <div class="info-card">
+                    <h3>📊 Kommunikations-Stats</h3>
+                    <ul class="info-list">
+                        <li><strong>Nachrichten gesamt:</strong> ${stats.total ?? 0}</li>
+                        <li><strong>Gelesen:</strong> ${stats.read ?? 0}</li>
+                        <li><strong>Antwort benötigt:</strong> ${stats.needs_response ?? 0}</li>
+                        <li><strong>Antworten gesendet:</strong> ${stats.responses_submitted ?? 0}</li>
+                    </ul>
+                </div>
+                <div class="info-card">
+                    <h3>🧩 Feature-Usage</h3>
+                    ${usageList}
+                </div>
+                <div class="info-card">
+                    <h3>🗂️ Letzte Features & Feedback</h3>
+                    ${recentTimeline}
+                </div>
+            `;
+        }
+
+        function loadBetaStatus() {
+            if (betaStatusCache) {
+                renderBetaStatus(betaStatusCache);
+                return;
+            }
+
+            fetchJson('?ajax=beta_status')
+                .then((data) => {
+                    betaStatusCache = data;
+                    renderBetaStatus(data);
+                })
+                .catch((error) => {
+                    console.error('Beta-Status konnte nicht geladen werden:', error);
+                });
+        }
+        function getActiveTab() {
+            const active = panelTabs.find((btn) => btn.classList.contains('active'));
+            return active ? active.dataset.tab : 'messages';
+        }
+
+        setInterval(() => {
+            if (!panelSettings.notifications) {
+                return;
+            }
+
+            loadMessages();
+            const activeTab = getActiveTab();
+            if (activeTab === 'activity') {
+                activityDataCache = null;
+                loadActivity();
+            } else if (activeTab === 'beta-status') {
+                betaStatusCache = null;
+                loadBetaStatus();
+            }
         }, 30000);
 
+        document.addEventListener('visibilitychange', () => {
+            if (!document.hidden && panelSettings.notifications) {
+                loadMessages();
+            }
+        });
+
+        applyPanelPreferences();
         loadMessages();
     </script>
 </body>


### PR DESCRIPTION
## Summary
- add response-tracking schema support and richer AJAX endpoints to the beta dashboard
- rebuild the beta customer panel with multi-tab navigation, read archives and yes/no responses
- extend the admin beta messaging tools with analytics, templates and response exports

## Testing
- php -l beta/index.php
- php -l admin/beta_messaging.php
- php -l admin/migrate.php

------
https://chatgpt.com/codex/tasks/task_e_68caba863cb8832383b79f308df98cf7