### PR TITLE
Add response statistics display to admin beta messaging

### DIFF
--- a/admin/beta_messaging.php
+++ b/admin/beta_messaging.php
@@ -173,63 +173,52 @@ Beispiele:
     </div>
     <?php if(!empty($response_stats)): ?>
     <div style="background:white;padding:2rem;border-radius:12px;box-shadow:0 2px 8px rgba(0,0,0,0.1);margin-top:2rem;">
-        <h3>📊 Ja/Nein Antworten</h3>
+        <h3>📊 Ja/Nein Antworten Statistik</h3>
+        
         <?php foreach($response_stats as $stat): ?>
-            <?php
-            $yesCount = (int)($stat['yes_count'] ?? 0);
-            $noCount = (int)($stat['no_count'] ?? 0);
-            if(($yesCount > 0) || ($noCount > 0)):
-            ?>
-            <div style="border:1px solid #e5e7eb;border-radius:8px;padding:1rem;margin:1rem 0;">
-                <div style="font-weight:600;margin-bottom:1rem;">"<?=htmlspecialchars($stat['message_text'])?>"</div>
-                <div style="display:flex;gap:1rem;text-align:center;">
-                    <div style="background:#dcfce7;padding:1rem;border-radius:6px;flex:1;">
-                        <div style="font-size:1.5rem;font-weight:bold;color:#15803d;"><?=$yesCount?></div>
-                        <div style="color:#15803d;">✅ Ja</div>
+        <?php 
+        $total = ($stat['yes_count'] ?? 0) + ($stat['no_count'] ?? 0);
+        if($total > 0): 
+        ?>
+        <div style="border:1px solid #e5e7eb;border-radius:8px;padding:1.5rem;margin:1rem 0;">
+            <div style="font-weight:600;margin-bottom:1rem;color:#374151;">
+                "<?=htmlspecialchars($stat['message_text'])?>"
+            </div>
+            
+            <div style="display:grid;grid-template-columns:1fr 1fr 1fr;gap:1rem;text-align:center;">
+                <div style="background:#dcfce7;padding:1rem;border-radius:6px;">
+                    <div style="font-size:1.5rem;font-weight:bold;color:#15803d;">
+                        <?=(int)$stat['yes_count']?>
                     </div>
-                    <div style="background:#fef2f2;padding:1rem;border-radius:6px;flex:1;">
-                        <div style="font-size:1.5rem;font-weight:bold;color:#dc2626;"><?=$noCount?></div>
-                        <div style="color:#dc2626;">❌ Nein</div>
+                    <div style="font-size:0.875rem;color:#15803d;font-weight:500;">✅ Ja</div>
+                </div>
+                
+                <div style="background:#fef2f2;padding:1rem;border-radius:6px;">
+                    <div style="font-size:1.5rem;font-weight:bold;color:#dc2626;">
+                        <?=(int)$stat['no_count']?>
                     </div>
+                    <div style="font-size:0.875rem;color:#dc2626;font-weight:500;">❌ Nein</div>
+                </div>
+                
+                <div style="background:#f3f4f6;padding:1rem;border-radius:6px;">
+                    <div style="font-size:1.5rem;font-weight:bold;color:#374151;">
+                        <?=$total?>
+                    </div>
+                    <div style="font-size:0.875rem;color:#6b7280;font-weight:500;">📊 Total</div>
                 </div>
             </div>
-            <?php endif; ?>
+            
+            <?php 
+            $yes_percentage = $total > 0 ? round(((int)$stat['yes_count'] / $total) * 100) : 0;
+            ?>
+            <div style="margin-top:1rem;text-align:center;font-weight:600;color:#374151;">
+                <?=$yes_percentage?>% Zustimmung
+            </div>
+        </div>
+        <?php endif; ?>
         <?php endforeach; ?>
     </div>
     <?php endif; ?>
-    <?php
-    $debug_responses = $pdo->query("SELECT m.id, m.message_text, m.expects_response, r.response, r.created_at as response_time 
-                                   FROM beta_messages m 
-                                   LEFT JOIN beta_responses r ON m.id = r.message_id 
-                                   WHERE m.to_customer_email = 'marcus@einfachstarten.jetzt' 
-                                   ORDER BY m.created_at DESC");
-    $all_responses = $debug_responses->fetchAll(PDO::FETCH_ASSOC);
-    ?>
-
-    <div style="background:white;padding:2rem;border-radius:12px;box-shadow:0 2px 8px rgba(0,0,0,0.1);margin-top:2rem;">
-        <h3>📊 Ja/Nein Antworten Debug</h3>
-        <?php if (empty($all_responses)): ?>
-            <p>Keine Messages gefunden</p>
-        <?php else: ?>
-            <div style="background:#f8f9fa;padding:1rem;border-radius:6px;margin:1rem 0;font-family:monospace;font-size:0.875rem;">
-                Total Messages: <?=count($all_responses)?><br>
-                Mit expects_response: <?=count(array_filter($all_responses, fn($r) => $r['expects_response']))?><br>
-                Mit Antworten: <?=count(array_filter($all_responses, fn($r) => $r['response']))?>
-            </div>
-            <?php foreach ($all_responses as $resp): ?>
-            <div style="border:1px solid #e5e7eb;padding:1rem;margin:0.5rem 0;border-radius:6px;">
-                <div style="font-weight:600;"><?=htmlspecialchars(mb_strimwidth($resp['message_text'], 0, 60, '...'))?></div>
-                <div style="font-size:0.875rem;color:#6b7280;">
-                    Expects Response: <?=$resp['expects_response'] ? 'JA' : 'NEIN'?><br>
-                    User Antwort: <?=$resp['response'] ? htmlspecialchars($resp['response']) : 'Keine'?><br>
-                    <?php if ($resp['response_time']): ?>
-                    Geantwortet: <?=date('d.m.Y H:i', strtotime($resp['response_time']))?>
-                    <?php endif; ?>
-                </div>
-            </div>
-            <?php endforeach; ?>
-        <?php endif; ?>
-    </div>
 </div>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add a styled statistics card to show yes/no response counts and totals for beta messages
- calculate total responses and approval percentage for each question in the admin view

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ced20245408323a400da5709449d9f