### PR TITLE
Add admin messaging center and refresh beta UI

### DIFF
--- a/admin/dashboard.php
+++ b/admin/dashboard.php
@@ -388,7 +388,7 @@ $email_stats = getEmailDeliveryStats(7);
     <a href="test_mail.php">E-Mail testen</a>
     <a href="analytics.php">Kunden-Analytics</a>
     <a href="migrate.php">Datenbank-Migration</a>
-    <a href="beta_messaging.php">🧪 Beta Messaging</a>
+    <a href="messaging.php">📨 Messaging Center</a>
     <a href="?logout=1">Abmelden</a>
 </nav>
 <?php if(!empty($_GET['success'])): ?>

--- a/admin/messaging.php
+++ b/admin/messaging.php
@@ -1,0 +1,766 @@
+<?php
+session_start();
+if (empty($_SESSION['admin'])) {
+    header('Location: login.php');
+    exit;
+}
+
+function getPDO(): PDO
+{
+    $config = require __DIR__ . '/config.php';
+
+    return new PDO(
+        "mysql:host={$config['DB_HOST']};dbname={$config['DB_NAME']};charset=utf8mb4",
+        $config['DB_USER'],
+        $config['DB_PASS'],
+        [PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION]
+    );
+}
+
+$pdo = getPDO();
+
+// Ensure beta messaging tables exist
+$pdo->exec("
+    CREATE TABLE IF NOT EXISTS beta_messages (
+        id INT AUTO_INCREMENT PRIMARY KEY,
+        from_admin BOOLEAN DEFAULT TRUE,
+        to_customer_email VARCHAR(100) NOT NULL,
+        message_text TEXT NOT NULL,
+        message_type ENUM('info', 'success', 'warning', 'question') DEFAULT 'info',
+        expects_response TINYINT(1) DEFAULT 0,
+        is_read BOOLEAN DEFAULT FALSE,
+        created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+        INDEX idx_customer_email (to_customer_email),
+        INDEX idx_unread (is_read, to_customer_email),
+        INDEX idx_created (created_at)
+    ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+");
+
+try {
+    $pdo->exec("ALTER TABLE beta_messages ADD COLUMN expects_response TINYINT(1) DEFAULT 0");
+} catch (PDOException $e) {
+    if ($e->getCode() !== '42S21') {
+        throw $e;
+    }
+}
+
+$pdo->exec("
+    CREATE TABLE IF NOT EXISTS beta_responses (
+        id INT AUTO_INCREMENT PRIMARY KEY,
+        message_id INT NOT NULL UNIQUE,
+        response ENUM('yes', 'no') NOT NULL,
+        created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+        FOREIGN KEY (message_id) REFERENCES beta_messages(id) ON DELETE CASCADE
+    ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+");
+
+$success_msg = '';
+$error_msg = '';
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST' && !empty($_POST['send_message'])) {
+    $message = trim($_POST['message'] ?? '');
+    $type = $_POST['type'] ?? 'info';
+    $recipients = $_POST['recipients'] ?? 'all';
+    $expects_response = !empty($_POST['expects_response']) ? 1 : 0;
+
+    $allowedTypes = ['info', 'success', 'warning', 'question'];
+    if (!in_array($type, $allowedTypes, true)) {
+        $type = 'info';
+    }
+
+    if ($message === '') {
+        $error_msg = 'Bitte gib eine Nachricht ein.';
+    } else {
+        if ($recipients === 'all') {
+            $customerStmt = $pdo->query("SELECT email FROM customers WHERE status = 'active'");
+            $customers = $customerStmt->fetchAll(PDO::FETCH_ASSOC);
+
+            if ($customers) {
+                $stmt = $pdo->prepare('
+                    INSERT INTO beta_messages (to_customer_email, message_text, message_type, expects_response)
+                    VALUES (?, ?, ?, ?)
+                ');
+
+                foreach ($customers as $c) {
+                    $stmt->execute([
+                        $c['email'],
+                        $message,
+                        $type,
+                        $expects_response
+                    ]);
+                }
+
+                $success_msg = 'Nachricht an ' . count($customers) . ' Kunden gesendet!';
+            } else {
+                $error_msg = 'Keine aktiven Kunden gefunden.';
+            }
+        } else {
+            $stmt = $pdo->prepare('
+                INSERT INTO beta_messages (to_customer_email, message_text, message_type, expects_response)
+                VALUES (?, ?, ?, ?)
+            ');
+            $stmt->execute([
+                $recipients,
+                $message,
+                $type,
+                $expects_response
+            ]);
+
+            $success_msg = 'Nachricht an ' . htmlspecialchars($recipients, ENT_QUOTES, 'UTF-8') . ' gesendet!';
+        }
+    }
+}
+
+$statsStmt = $pdo->query('
+    SELECT
+        COUNT(DISTINCT to_customer_email) AS total_customers,
+        COUNT(*) AS total_messages,
+        SUM(is_read = 1) AS read_messages,
+        SUM(is_read = 0) AS unread_messages
+    FROM beta_messages
+');
+$stats = $statsStmt->fetch(PDO::FETCH_ASSOC) ?: [];
+
+$totalMessages = (int)($stats['total_messages'] ?? 0);
+$readMessages = (int)($stats['read_messages'] ?? 0);
+$unreadMessages = (int)($stats['unread_messages'] ?? 0);
+$readPercentage = $totalMessages > 0 ? round(($readMessages / $totalMessages) * 100) : 0;
+
+$customerQuery = $pdo->query('
+    SELECT
+        c.*,
+        COUNT(m.id) AS total_messages,
+        SUM(m.is_read = 0) AS unread_messages,
+        MAX(m.created_at) AS last_message
+    FROM customers c
+    LEFT JOIN beta_messages m ON m.to_customer_email = c.email
+    WHERE c.status = "active"
+    GROUP BY c.id
+    ORDER BY unread_messages DESC, c.last_name ASC
+');
+$customers = $customerQuery->fetchAll(PDO::FETCH_ASSOC);
+
+foreach ($customers as &$customer) {
+    $customer['total_messages'] = (int)($customer['total_messages'] ?? 0);
+    $customer['unread_messages'] = (int)($customer['unread_messages'] ?? 0);
+}
+unset($customer);
+
+$selected_customer = $_GET['customer'] ?? null;
+
+?>
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="UTF-8">
+    <title>📨 Messaging Center</title>
+    <style>
+        * { box-sizing: border-box; margin: 0; padding: 0; }
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+            background: #f8fafc;
+            line-height: 1.5;
+        }
+
+        .container {
+            display: flex;
+            height: 100vh;
+            max-width: 1400px;
+            margin: 0 auto;
+            background: white;
+            box-shadow: 0 0 30px rgba(0,0,0,0.1);
+        }
+
+        .sidebar {
+            width: 350px;
+            background: white;
+            border-right: 1px solid #e5e7eb;
+            display: flex;
+            flex-direction: column;
+        }
+
+        .sidebar-header {
+            padding: 1.5rem;
+            background: linear-gradient(135deg, #4a90b8, #52b3a4);
+            color: white;
+        }
+
+        .sidebar-header h2 {
+            font-size: 1.25rem;
+            margin-bottom: 0.5rem;
+        }
+
+        .stats-grid {
+            display: grid;
+            grid-template-columns: 1fr 1fr;
+            gap: 0.5rem;
+            margin-top: 1rem;
+        }
+
+        .stat-box {
+            background: rgba(255,255,255,0.1);
+            padding: 0.5rem;
+            border-radius: 8px;
+        }
+
+        .stat-value {
+            font-size: 1.5rem;
+            font-weight: bold;
+        }
+
+        .stat-label {
+            font-size: 0.75rem;
+            opacity: 0.9;
+        }
+
+        .customer-list-header {
+            padding: 1rem;
+            background: #f8fafc;
+            border-bottom: 1px solid #e5e7eb;
+        }
+
+        .search-box {
+            width: 100%;
+            padding: 0.5rem 1rem;
+            border: 1px solid #e5e7eb;
+            border-radius: 20px;
+            font-size: 0.9rem;
+            outline: none;
+        }
+
+        .customer-list {
+            flex: 1;
+            overflow-y: auto;
+        }
+
+        .customer-item {
+            padding: 1rem;
+            border-bottom: 1px solid #f0f0f0;
+            cursor: pointer;
+            transition: background 0.2s;
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+        }
+
+        .customer-item:hover {
+            background: #f8fafc;
+        }
+
+        .customer-item.active {
+            background: #e3f2fd;
+            border-left: 3px solid #4a90b8;
+        }
+
+        .customer-info {
+            flex: 1;
+        }
+
+        .customer-name {
+            font-weight: 600;
+            color: #1c1e21;
+            margin-bottom: 0.25rem;
+        }
+
+        .customer-email {
+            font-size: 0.85rem;
+            color: #65676b;
+        }
+
+        .customer-stats {
+            text-align: right;
+        }
+
+        .unread-badge {
+            background: #ff4444;
+            color: white;
+            padding: 2px 8px;
+            border-radius: 12px;
+            font-size: 0.75rem;
+            font-weight: bold;
+        }
+
+        .last-seen {
+            font-size: 0.75rem;
+            color: #8a8d91;
+            margin-top: 0.25rem;
+        }
+
+        .main-content {
+            flex: 1;
+            display: flex;
+            flex-direction: column;
+            background: #f8fafc;
+        }
+
+        .compose-header {
+            padding: 1.5rem;
+            background: white;
+            border-bottom: 1px solid #e5e7eb;
+        }
+
+        .compose-form {
+            background: white;
+            padding: 1.5rem;
+            margin: 1.5rem;
+            border-radius: 12px;
+            box-shadow: 0 2px 10px rgba(0,0,0,0.05);
+        }
+
+        .form-group {
+            margin-bottom: 1.5rem;
+        }
+
+        .form-label {
+            display: block;
+            margin-bottom: 0.5rem;
+            font-weight: 600;
+            color: #374151;
+        }
+
+        .recipient-select {
+            width: 100%;
+            padding: 0.75rem;
+            border: 1px solid #e5e7eb;
+            border-radius: 8px;
+            font-size: 1rem;
+            outline: none;
+            background: white;
+        }
+
+        .message-types {
+            display: flex;
+            gap: 1rem;
+            margin-bottom: 1rem;
+        }
+
+        .type-btn {
+            padding: 0.5rem 1rem;
+            border: 2px solid #e5e7eb;
+            background: white;
+            border-radius: 8px;
+            cursor: pointer;
+            transition: all 0.2s;
+        }
+
+        .type-btn.active {
+            background: #4a90b8;
+            color: white;
+            border-color: #4a90b8;
+        }
+
+        .message-textarea {
+            width: 100%;
+            min-height: 150px;
+            padding: 0.75rem;
+            border: 1px solid #e5e7eb;
+            border-radius: 8px;
+            font-family: inherit;
+            font-size: 1rem;
+            resize: vertical;
+            outline: none;
+        }
+
+        .message-textarea:focus {
+            border-color: #4a90b8;
+            box-shadow: 0 0 0 3px rgba(74, 144, 184, 0.1);
+        }
+
+        .form-footer {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+        }
+
+        .checkbox-label {
+            display: flex;
+            align-items: center;
+            gap: 0.5rem;
+            cursor: pointer;
+        }
+
+        .send-btn {
+            padding: 0.75rem 2rem;
+            background: linear-gradient(135deg, #4a90b8, #52b3a4);
+            color: white;
+            border: none;
+            border-radius: 8px;
+            font-weight: 600;
+            cursor: pointer;
+            transition: transform 0.2s;
+        }
+
+        .send-btn:hover {
+            transform: translateY(-2px);
+        }
+
+        .history-area {
+            flex: 1;
+            overflow-y: auto;
+            padding: 1.5rem;
+        }
+
+        .history-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 1rem;
+        }
+
+        .message-card {
+            background: white;
+            border-radius: 12px;
+            padding: 1rem;
+            margin-bottom: 1rem;
+            border-left: 4px solid;
+            box-shadow: 0 2px 5px rgba(0,0,0,0.05);
+        }
+
+        .message-card.type-info { border-left-color: #3b82f6; }
+        .message-card.type-success { border-left-color: #10b981; }
+        .message-card.type-warning { border-left-color: #f59e0b; }
+        .message-card.type-question { border-left-color: #8b5cf6; }
+
+        .message-meta {
+            display: flex;
+            justify-content: space-between;
+            margin-bottom: 0.5rem;
+            font-size: 0.85rem;
+            color: #6b7280;
+        }
+
+        .message-status {
+            display: flex;
+            align-items: center;
+            gap: 0.5rem;
+        }
+
+        .status-badge {
+            padding: 2px 8px;
+            border-radius: 12px;
+            font-size: 0.75rem;
+            font-weight: 600;
+        }
+
+        .status-read {
+            background: #d4f4dd;
+            color: #00875a;
+        }
+
+        .status-unread {
+            background: #fee2e2;
+            color: #dc3545;
+        }
+
+        .message-content {
+            color: #374151;
+            line-height: 1.5;
+        }
+
+        .response-stats {
+            margin-top: 0.75rem;
+            padding-top: 0.75rem;
+            border-top: 1px solid #f3f4f6;
+            display: flex;
+            gap: 1rem;
+        }
+
+        .response-stat {
+            display: flex;
+            align-items: center;
+            gap: 0.25rem;
+            font-size: 0.85rem;
+        }
+
+        .alert-success {
+            background: #d4f4dd;
+            color: #00875a;
+            padding: 1rem;
+            border-radius: 8px;
+            margin: 1rem;
+            display: flex;
+            align-items: center;
+            gap: 0.5rem;
+        }
+
+        .alert-success::before {
+            content: '✅';
+        }
+
+        .alert-error {
+            background: #fee2e2;
+            color: #dc2626;
+            padding: 1rem;
+            border-radius: 8px;
+            margin: 1rem;
+            display: flex;
+            align-items: center;
+            gap: 0.5rem;
+        }
+
+        .alert-error::before {
+            content: '⚠️';
+        }
+
+        .broadcast-btn {
+            position: fixed;
+            bottom: 2rem;
+            right: 2rem;
+            padding: 1rem 1.5rem;
+            background: linear-gradient(135deg, #667eea, #764ba2);
+            color: white;
+            border: none;
+            border-radius: 50px;
+            font-weight: 600;
+            cursor: pointer;
+            box-shadow: 0 4px 20px rgba(0,0,0,0.2);
+            display: flex;
+            align-items: center;
+            gap: 0.5rem;
+            transition: transform 0.2s;
+        }
+
+        .broadcast-btn:hover {
+            transform: scale(1.05);
+        }
+    </style>
+</head>
+<body>
+
+<div class="container">
+    <div class="sidebar">
+        <div class="sidebar-header">
+            <h2>📨 Messaging Center</h2>
+            <div class="stats-grid">
+                <div class="stat-box">
+                    <div class="stat-value"><?= (int)($stats['total_customers'] ?? 0) ?></div>
+                    <div class="stat-label">Kunden</div>
+                </div>
+                <div class="stat-box">
+                    <div class="stat-value"><?= $totalMessages ?></div>
+                    <div class="stat-label">Nachrichten</div>
+                </div>
+                <div class="stat-box">
+                    <div class="stat-value"><?= $readPercentage ?>%</div>
+                    <div class="stat-label">Gelesen</div>
+                </div>
+                <div class="stat-box">
+                    <div class="stat-value"><?= $unreadMessages ?></div>
+                    <div class="stat-label">Ungelesen</div>
+                </div>
+            </div>
+        </div>
+
+        <div class="customer-list-header">
+            <input type="text"
+                   class="search-box"
+                   placeholder="🔍 Kunde suchen..."
+                   onkeyup="filterCustomers(this.value)">
+        </div>
+
+        <div class="customer-list" id="customerList">
+            <?php foreach ($customers as $c):
+                $is_active = $selected_customer === $c['email'];
+                $data_name = strtolower(($c['first_name'] ?? '') . ' ' . ($c['last_name'] ?? ''));
+                ?>
+                <div class="customer-item <?= $is_active ? 'active' : '' ?>"
+                     onclick="selectCustomer('<?= htmlspecialchars($c['email'], ENT_QUOTES, 'UTF-8') ?>')"
+                     data-name="<?= htmlspecialchars($data_name, ENT_QUOTES, 'UTF-8') ?>">
+                    <div class="customer-info">
+                        <div class="customer-name">
+                            <?= htmlspecialchars(($c['first_name'] ?? '') . ' ' . ($c['last_name'] ?? ''), ENT_QUOTES, 'UTF-8') ?>
+                        </div>
+                        <div class="customer-email">
+                            <?= htmlspecialchars($c['email'] ?? '', ENT_QUOTES, 'UTF-8') ?>
+                        </div>
+                    </div>
+                    <div class="customer-stats">
+                        <?php if (($c['unread_messages'] ?? 0) > 0): ?>
+                            <div class="unread-badge"><?= (int)$c['unread_messages'] ?> neu</div>
+                        <?php endif; ?>
+                        <?php if (!empty($c['last_message'])): ?>
+                            <div class="last-seen">
+                                <?= date('d.m.y', strtotime($c['last_message'])) ?>
+                            </div>
+                        <?php endif; ?>
+                    </div>
+                </div>
+            <?php endforeach; ?>
+        </div>
+    </div>
+
+    <div class="main-content">
+        <div class="compose-header">
+            <h2>Neue Nachricht versenden</h2>
+            <p><a href="dashboard.php">← Zurück zum Dashboard</a></p>
+        </div>
+
+        <?php if (!empty($success_msg)): ?>
+            <div class="alert-success">
+                <?= htmlspecialchars($success_msg, ENT_QUOTES, 'UTF-8') ?>
+            </div>
+        <?php endif; ?>
+
+        <?php if (!empty($error_msg)): ?>
+            <div class="alert-error">
+                <?= htmlspecialchars($error_msg, ENT_QUOTES, 'UTF-8') ?>
+            </div>
+        <?php endif; ?>
+
+        <form method="POST" class="compose-form">
+            <input type="hidden" name="send_message" value="1">
+
+            <div class="form-group">
+                <label class="form-label">Empfänger</label>
+                <select name="recipients" class="recipient-select" id="recipientSelect">
+                    <option value="all">📢 Alle aktiven Kunden (Broadcast)</option>
+                    <optgroup label="Einzelne Kunden">
+                        <?php foreach ($customers as $c): ?>
+                            <option value="<?= htmlspecialchars($c['email'] ?? '', ENT_QUOTES, 'UTF-8') ?>"
+                                <?= $selected_customer === ($c['email'] ?? '') ? 'selected' : '' ?>>
+                                <?= htmlspecialchars(($c['first_name'] ?? '') . ' ' . ($c['last_name'] ?? ''), ENT_QUOTES, 'UTF-8') ?>
+                                (<?= htmlspecialchars($c['email'] ?? '', ENT_QUOTES, 'UTF-8') ?>)
+                            </option>
+                        <?php endforeach; ?>
+                    </optgroup>
+                </select>
+            </div>
+
+            <div class="form-group">
+                <label class="form-label">Nachrichtentyp</label>
+                <div class="message-types">
+                    <button type="button" class="type-btn active" onclick="setMessageType(this, 'info')">
+                        ℹ️ Information
+                    </button>
+                    <button type="button" class="type-btn" onclick="setMessageType(this, 'success')">
+                        ✅ Erfolg
+                    </button>
+                    <button type="button" class="type-btn" onclick="setMessageType(this, 'warning')">
+                        ⚠️ Warnung
+                    </button>
+                    <button type="button" class="type-btn" onclick="setMessageType(this, 'question')">
+                        ❓ Frage
+                    </button>
+                </div>
+                <input type="hidden" name="type" value="info" id="messageType">
+            </div>
+
+            <div class="form-group">
+                <label class="form-label">Nachricht</label>
+                <textarea name="message"
+                          class="message-textarea"
+                          placeholder="Schreibe deine Nachricht hier..."
+                          required></textarea>
+            </div>
+
+            <div class="form-footer">
+                <label class="checkbox-label">
+                    <input type="checkbox" name="expects_response" value="1">
+                    <span>Ja/Nein Antwort erwarten</span>
+                </label>
+                <button type="submit" class="send-btn">
+                    Nachricht senden →
+                </button>
+            </div>
+        </form>
+
+        <?php if ($selected_customer): ?>
+            <div class="history-area">
+                <div class="history-header">
+                    <h3>Nachrichtenverlauf: <?= htmlspecialchars($selected_customer, ENT_QUOTES, 'UTF-8') ?></h3>
+                    <span style="color:#6b7280;font-size:0.9rem;">
+                        <?php
+                        $countStmt = $pdo->prepare('SELECT COUNT(*) FROM beta_messages WHERE to_customer_email = ?');
+                        $countStmt->execute([$selected_customer]);
+                        echo (int)$countStmt->fetchColumn() . ' Nachrichten';
+                        ?>
+                    </span>
+                </div>
+
+                <?php
+                $historyStmt = $pdo->prepare('
+                    SELECT m.*,
+                           (SELECT response FROM beta_responses WHERE message_id = m.id) AS user_response
+                    FROM beta_messages m
+                    WHERE to_customer_email = ?
+                    ORDER BY created_at DESC
+                    LIMIT 20
+                ');
+                $historyStmt->execute([$selected_customer]);
+                $messages = $historyStmt->fetchAll(PDO::FETCH_ASSOC);
+                ?>
+
+                <?php foreach ($messages as $msg):
+                    $messageType = htmlspecialchars($msg['message_type'] ?? 'info', ENT_QUOTES, 'UTF-8');
+                    $isRead = !empty($msg['is_read']);
+                    $expectsResponse = !empty($msg['expects_response']);
+                    $userResponse = $msg['user_response'] ?? null;
+                    ?>
+                    <div class="message-card type-<?= $messageType ?>">
+                        <div class="message-meta">
+                            <span><?= date('d.m.Y H:i', strtotime($msg['created_at'])) ?></span>
+                            <div class="message-status">
+                                <span class="status-badge <?= $isRead ? 'status-read' : 'status-unread' ?>">
+                                    <?= $isRead ? '✓ Gelesen' : '● Ungelesen' ?>
+                                </span>
+                            </div>
+                        </div>
+                        <div class="message-content">
+                            <?= nl2br(htmlspecialchars($msg['message_text'] ?? '', ENT_QUOTES, 'UTF-8')) ?>
+                        </div>
+                        <?php if ($expectsResponse): ?>
+                            <div class="response-stats">
+                                <div class="response-stat">
+                                    <?php if ($userResponse === 'yes'): ?>
+                                        <span style="color:#10b981;">✅ Antwort: Ja</span>
+                                    <?php elseif ($userResponse === 'no'): ?>
+                                        <span style="color:#ef4444;">❌ Antwort: Nein</span>
+                                    <?php else: ?>
+                                        <span style="color:#6b7280;">⏳ Antwort ausstehend</span>
+                                    <?php endif; ?>
+                                </div>
+                            </div>
+                        <?php endif; ?>
+                    </div>
+                <?php endforeach; ?>
+            </div>
+        <?php endif; ?>
+    </div>
+</div>
+
+<button class="broadcast-btn" type="button" onclick="document.getElementById('recipientSelect').value='all'; window.scrollTo({top: 0, behavior: 'smooth'});">
+    📢 Broadcast an alle
+</button>
+
+<script>
+function selectCustomer(email) {
+    const url = new URL(window.location.href);
+    url.searchParams.set('customer', email);
+    window.location.href = url.toString();
+}
+
+function filterCustomers(query) {
+    const q = (query || '').toLowerCase();
+    const items = document.querySelectorAll('.customer-item');
+
+    items.forEach(item => {
+        const name = item.dataset.name || '';
+        const email = item.querySelector('.customer-email').textContent.toLowerCase();
+
+        if (name.includes(q) || email.includes(q)) {
+            item.style.display = 'flex';
+        } else {
+            item.style.display = 'none';
+        }
+    });
+}
+
+function setMessageType(button, type) {
+    document.querySelectorAll('.type-btn').forEach(btn => btn.classList.remove('active'));
+    button.classList.add('active');
+    document.getElementById('messageType').value = type;
+}
+</script>
+
+</body>
+</html>

--- a/beta/index.php
+++ b/beta/index.php
@@ -137,8 +137,6 @@ $initialUnreadCount = (int) $stmt->fetchColumn();
         :root {
             --primary: #4a90b8;
             --secondary: #52b3a4;
-            --accent-green: #7cb342;
-            --accent-teal: #26a69a;
             --light-blue: #e3f2fd;
             --white: #ffffff;
             --gray-light: #f8f9fa;
@@ -162,39 +160,6 @@ $initialUnreadCount = (int) $stmt->fetchColumn();
             color: var(--gray-dark);
             font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
             line-height: 1.5;
-        }
-
-        .beta-banner {
-            background: linear-gradient(45deg, #667eea, #764ba2);
-            color: white;
-            padding: 0.5rem;
-            text-align: center;
-            font-weight: bold;
-            font-size: 0.85rem;
-            animation: betaPulse 3s ease-in-out infinite;
-            position: relative;
-            overflow: hidden;
-        }
-
-        @keyframes betaPulse {
-            0%, 100% { opacity: 1; }
-            50% { opacity: 0.9; }
-        }
-
-        .beta-banner::before {
-            content: '';
-            position: absolute;
-            top: -50%;
-            left: -50%;
-            width: 200%;
-            height: 200%;
-            background: linear-gradient(45deg, transparent, rgba(255,255,255,0.1), transparent);
-            animation: shimmer 4s linear infinite;
-        }
-
-        @keyframes shimmer {
-            0% { transform: translateX(-100%) translateY(-100%) rotate(45deg); }
-            100% { transform: translateX(100%) translateY(100%) rotate(45deg); }
         }
 
         .app-container {
@@ -244,39 +209,36 @@ $initialUnreadCount = (int) $stmt->fetchColumn();
             justify-content: center;
             font-size: 1.8rem;
             border: 2px solid rgba(255, 255, 255, 0.3);
-            cursor: pointer;
-            transition: all 0.3s ease;
             position: relative;
         }
 
-        .user-avatar:hover {
+        .user-avatar.clickable {
+            cursor: pointer;
+            transition: all 0.3s ease;
+        }
+
+        .user-avatar.clickable:hover {
             transform: scale(1.05);
             border-color: rgba(255, 255, 255, 0.6);
             box-shadow: 0 4px 15px rgba(255, 255, 255, 0.2);
         }
 
-        .message-badge {
+        .notification-badge {
             position: absolute;
             top: -5px;
             right: -5px;
-            background: #ff4757;
+            background: #ff4444;
             color: white;
             border-radius: 50%;
-            width: 24px;
-            height: 24px;
+            min-width: 20px;
+            height: 20px;
             display: flex;
             align-items: center;
             justify-content: center;
-            font-size: 0.75rem;
+            font-size: 0.7rem;
             font-weight: bold;
             border: 2px solid white;
-            animation: badgePulse 2s infinite;
-            min-width: 24px;
-        }
-
-        @keyframes badgePulse {
-            0%, 100% { transform: scale(1); }
-            50% { transform: scale(1.1); }
+            z-index: 10;
         }
 
         .user-info h1 {
@@ -316,6 +278,117 @@ $initialUnreadCount = (int) $stmt->fetchColumn();
             padding: 1.5rem;
         }
 
+        .welcome-section {
+            text-align: center;
+            margin-bottom: 2rem;
+            padding: 1.5rem;
+            background: var(--light-blue);
+            border-radius: 16px;
+            border-left: 4px solid var(--primary);
+        }
+
+        .welcome-section h2 {
+            color: var(--primary);
+            margin-bottom: 0.5rem;
+            font-size: 1.2rem;
+        }
+
+        .welcome-section p {
+            color: var(--gray-medium);
+            font-size: 0.9rem;
+        }
+
+        .action-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+            gap: 1rem;
+            margin-top: 1rem;
+        }
+
+        .action-card {
+            background: white;
+            border-radius: 12px;
+            padding: 1.25rem;
+            box-shadow: 0 2px 10px var(--shadow);
+            border: 1px solid #f0f0f0;
+            text-decoration: none;
+            color: inherit;
+            transition: all 0.3s ease;
+            display: flex;
+            align-items: center;
+            gap: 1rem;
+        }
+
+        .action-card:hover {
+            transform: translateY(-2px);
+            box-shadow: 0 6px 20px var(--shadow);
+            text-decoration: none;
+            color: inherit;
+        }
+
+        .action-icon {
+            width: 45px;
+            height: 45px;
+            border-radius: 12px;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            font-size: 1.4rem;
+            background: linear-gradient(135deg, var(--primary) 0%, var(--secondary) 100%);
+        }
+
+        .action-content h3 {
+            margin: 0;
+            font-size: 1rem;
+            font-weight: 600;
+            color: var(--gray-dark);
+        }
+
+        .action-content p {
+            margin: 0.25rem 0 0 0;
+            font-size: 0.85rem;
+            color: var(--gray-medium);
+        }
+
+        @media (max-width: 768px) {
+            .action-grid {
+                grid-template-columns: 1fr;
+            }
+
+            .app-content {
+                padding: 1rem;
+            }
+
+            .header-content {
+                gap: 0.75rem;
+            }
+
+            .user-avatar {
+                width: 50px;
+                height: 50px;
+                font-size: 1.5rem;
+            }
+        }
+
+        /* Message Panel Styles bleiben identisch - nicht ändern! */
+        .overlay {
+            position: fixed;
+            top: 0;
+            left: 0;
+            width: 100%;
+            height: 100%;
+            background: rgba(0,0,0,0.5);
+            z-index: 1000;
+            opacity: 0;
+            visibility: hidden;
+            transition: all 0.3s ease;
+        }
+
+        .overlay.active {
+            opacity: 1;
+            visibility: visible;
+        }
+
         .message-panel {
             position: fixed;
             top: 0;
@@ -343,9 +416,9 @@ $initialUnreadCount = (int) $stmt->fetchColumn();
             align-items: center;
         }
 
-        .message-tabs{display:flex;border-bottom:1px solid #e5e7eb;}
-        .message-tabs button{flex:1;padding:0.75rem;border:none;background:transparent;font-weight:600;color:var(--gray-medium);cursor:pointer;border-bottom:2px solid transparent;}
-        .message-tabs button.active{color:var(--primary);border-bottom-color:var(--primary);}
+        .message-tabs { display: flex; border-bottom: 1px solid #e5e7eb; }
+        .message-tabs button { flex: 1; padding: 0.75rem; border: none; background: transparent; font-weight: 600; color: var(--gray-medium); cursor: pointer; border-bottom: 2px solid transparent; }
+        .message-tabs button.active { color: var(--primary); border-bottom-color: var(--primary); }
 
         .close-panel {
             background: none;
@@ -405,137 +478,21 @@ $initialUnreadCount = (int) $stmt->fetchColumn();
             background: #218838;
             transform: translateY(-1px);
         }
-
-        .overlay {
-            position: fixed;
-            top: 0;
-            left: 0;
-            width: 100%;
-            height: 100%;
-            background: rgba(0,0,0,0.5);
-            z-index: 1000;
-            opacity: 0;
-            visibility: hidden;
-            transition: all 0.3s ease;
-        }
-
-        .overlay.active {
-            opacity: 1;
-            visibility: visible;
-        }
-
-        .welcome-section {
-            text-align: center;
-            margin-bottom: 2rem;
-            padding: 1.5rem;
-            background: var(--light-blue);
-            border-radius: 16px;
-            border-left: 4px solid var(--primary);
-        }
-
-        .welcome-section h2 {
-            color: var(--primary);
-            margin-bottom: 0.5rem;
-            font-size: 1.2rem;
-        }
-
-        .actions-grid {
-            display: grid;
-            grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
-            gap: 1rem;
-            margin-bottom: 2rem;
-        }
-
-        .action-card {
-            background: white;
-            border-radius: 12px;
-            padding: 1.25rem;
-            box-shadow: 0 2px 10px var(--shadow);
-            border: 1px solid #f0f0f0;
-            text-decoration: none;
-            color: inherit;
-            transition: all 0.3s ease;
-            display: flex;
-            align-items: center;
-            gap: 1rem;
-        }
-
-        .action-card:hover {
-            transform: translateY(-2px);
-            box-shadow: 0 6px 20px var(--shadow);
-            text-decoration: none;
-            color: inherit;
-        }
-
-        .action-icon {
-            width: 45px;
-            height: 45px;
-            border-radius: 12px;
-            display: flex;
-            align-items: center;
-            justify-content: center;
-            font-size: 1.4rem;
-            background: linear-gradient(135deg, var(--primary) 0%, var(--secondary) 100%);
-        }
-
-        .action-content h3 {
-            margin: 0;
-            font-size: 1rem;
-            font-weight: 600;
-            color: var(--gray-dark);
-        }
-
-        .action-content p {
-            margin: 0.25rem 0 0 0;
-            font-size: 0.85rem;
-            color: var(--gray-medium);
-        }
-
-        @media (max-width: 768px) {
-            .message-panel {
-                width: 100%;
-                right: -100%;
-            }
-
-            .actions-grid {
-                grid-template-columns: 1fr;
-            }
-
-            .header-content {
-                gap: 0.75rem;
-            }
-
-            .user-avatar {
-                width: 50px;
-                height: 50px;
-                font-size: 1.5rem;
-            }
-
-            .message-badge {
-                width: 20px;
-                height: 20px;
-                font-size: 0.65rem;
-            }
-        }
     </style>
 </head>
 <body>
-    <div class="beta-banner">
-        🧪 BETA VERSION - Experimentelle Features in Entwicklung
-    </div>
-
     <div class="app-container">
         <div class="app-header">
             <div class="header-content">
-                <div class="user-avatar" onclick="toggleMessagePanel()">
-                    👤
-                    <div class="message-badge" id="messageBadge" style="display: <?= $initialUnreadCount > 0 ? 'flex' : 'none' ?>;">
+                <div class="user-avatar clickable" onclick="toggleMessagePanel()">
+                    <?= strtoupper(substr($customer['first_name'], 0, 1)) ?>
+                    <div class="notification-badge" id="notificationBadge" style="display: <?= $initialUnreadCount > 0 ? 'flex' : 'none' ?>;">
                         <?= $initialUnreadCount > 99 ? '99+' : $initialUnreadCount; ?>
                     </div>
                 </div>
                 <div class="user-info">
-                    <h1>Beta-Modus: <?= htmlspecialchars($customer['first_name'], ENT_QUOTES, 'UTF-8'); ?></h1>
-                    <p>🧪 Testing new features</p>
+                    <h1>🧪 Beta: <?= htmlspecialchars($customer['first_name'], ENT_QUOTES, 'UTF-8'); ?></h1>
+                    <p>Testing neue Features vor Production</p>
                 </div>
                 <a href="../login.php?logout=1" class="logout-btn">
                     🚪 Abmelden
@@ -546,10 +503,10 @@ $initialUnreadCount = (int) $stmt->fetchColumn();
         <div class="app-content">
             <div class="welcome-section">
                 <h2>Willkommen in der Beta-Umgebung!</h2>
-                <p>Hier testest du neue Features bevor sie für alle verfügbar sind. Klicke auf dein Profilbild um Nachrichten zu sehen.</p>
+                <p>Du testest neue Features bevor sie für alle verfügbar sind. Klicke auf dein Profilbild um Nachrichten zu sehen.</p>
             </div>
 
-            <div class="actions-grid">
+            <div class="action-grid">
                 <a href="../customer/booking.php" class="action-card">
                     <div class="action-icon">📅</div>
                     <div class="action-content">
@@ -601,7 +558,7 @@ $initialUnreadCount = (int) $stmt->fetchColumn();
     <script>
         const messagePanel = document.getElementById('messagePanel');
         const overlay = document.getElementById('overlay');
-        const messageBadge = document.getElementById('messageBadge');
+        const notificationBadge = document.getElementById('notificationBadge');
         const messageList = document.getElementById('messageList');
         const tabButtons = document.querySelectorAll('.message-tabs button');
         let currentTab = 'new';
@@ -725,13 +682,16 @@ $initialUnreadCount = (int) $stmt->fetchColumn();
         }
 
         function updateMessageBadge(count) {
+            if (!notificationBadge) {
+                return;
+            }
             const parsed = Number(count) || 0;
 
             if (parsed > 0) {
-                messageBadge.style.display = 'flex';
-                messageBadge.textContent = parsed > 99 ? '99+' : parsed;
+                notificationBadge.style.display = 'flex';
+                notificationBadge.textContent = parsed > 99 ? '99+' : parsed;
             } else {
-                messageBadge.style.display = 'none';
+                notificationBadge.style.display = 'none';
             }
         }
 


### PR DESCRIPTION
## Summary
- add a new admin messaging center with broadcast and per-customer targeting, customer search, and message history
- update the admin dashboard shortcut to point at the new messaging center
- restyle the beta customer dashboard to align with the production look while keeping the live messaging panel intact

## Testing
- php -l admin/messaging.php
- php -l admin/dashboard.php
- php -l beta/index.php

------
https://chatgpt.com/codex/tasks/task_e_68cef195869083239b8f51662755c1ab