### PR TITLE
Implement production customer live messaging

### DIFF
--- a/customer/messaging_init.php
+++ b/customer/messaging_init.php
@@ -15,6 +15,14 @@ function ensureProductionMessagingTables(PDO $pdo): void
         INDEX idx_created (created_at)
     ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;");
 
+    try {
+        $pdo->exec("ALTER TABLE customer_messages ADD COLUMN expects_response TINYINT(1) DEFAULT 0");
+    } catch (PDOException $e) {
+        if ($e->getCode() !== '42S21') {
+            throw $e;
+        }
+    }
+
     $pdo->exec("CREATE TABLE IF NOT EXISTS customer_message_responses (
         id INT AUTO_INCREMENT PRIMARY KEY,
         message_id INT NOT NULL UNIQUE,


### PR DESCRIPTION
## Summary
- create customer messaging tables on login with an additional expects_response column check
- port the beta live messaging UI to the production customer dashboard with avatar badge and sliding panel
- add JavaScript to power the messaging panel with auto-refresh, response handling, and toast feedback

## Testing
- php -l customer/index.php
- php -l customer/messaging_init.php

------
https://chatgpt.com/codex/tasks/task_e_68d1325f2c9083238251085b4f3140fe